### PR TITLE
System tray is unavailable on KDE5

### DIFF
--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -120,8 +120,8 @@ int waitForTray()
 		if (++trayAttempts > TRAY_RETRY_COUNT)
 		{
 			QMessageBox::critical(NULL, "Synergy",
-				QObject::tr("System tray is unavailable, quitting."));
-			return false;
+				QObject::tr("System tray is unavailable, don't close your window."));
+			return true;
 		}
 
 		QThreadImpl::msleep(TRAY_RETRY_WAIT);


### PR DESCRIPTION
running when system tray is unavailable, but show message to user don't close window.
