### PR TITLE
Removed _BYTE_ORDER test in uSynergy for Solaris 11

### DIFF
--- a/src/micro/uSynergy.h
+++ b/src/micro/uSynergy.h
@@ -46,7 +46,7 @@ extern "C" {
 	#error "Can't define both USYNERGY_LITTLE_ENDIAN and USYNERGY_BIG_ENDIAN"
 #elif !defined(USYNERGY_LITTLE_ENDIAN) && !defined(USYNERGY_BIG_ENDIAN)
 	/* Attempt to auto detect */
-	#if defined(__LITTLE_ENDIAN__) || defined(LITTLE_ENDIAN) || (_BYTE_ORDER == _LITTLE_ENDIAN)
+	#if defined(__LITTLE_ENDIAN__) || defined(LITTLE_ENDIAN) 
 		#define USYNERGY_LITTLE_ENDIAN
 	#elif defined(__BIG_ENDIAN__) || defined(BIG_ENDIAN) || (_BYTE_ORDER == _BIG_ENDIAN)
 		#define USYNERGY_BIG_ENDIAN


### PR DESCRIPTION
I was unable to compile on Solaris 11 and noticed this was undefined anyway. Never committed to the project before and welcome feedback (however basic this change is)
