### PR TITLE
Only allow mouse buttons 1 to 10 on Linux

### DIFF
--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -826,7 +826,7 @@ void
 XWindowsScreen::fakeMouseButton(ButtonID button, bool press)
 {
 	const unsigned int xButton = mapButtonToX(button);
-	if (xButton != 0) {
+	if (xButton > 0 && xButton < 11) {
 		XTestFakeButtonEvent(m_display, xButton,
 							press ? True : False, CurrentTime);
 		XFlush(m_display);


### PR DESCRIPTION
These are the only valid ones:
[~]>for i in `seq 0 1 11`; do echo Testing $i; xte "mouseclick $i"; done
Testing 0
X Error of failed request:  BadValue (integer parameter out of range for operation)
  Major opcode of failed request:  132 (XTEST)
  Minor opcode of failed request:  2 (X_XTestFakeInput)
  Value in failed request:  0x0
  Serial number of failed request:  12
  Current serial number in output stream:  15
Testing 1
Testing 2
Testing 3
Testing 4
Testing 5
Testing 6
Testing 7
Testing 8
Testing 9
Testing 10
Testing 11
X Error of failed request:  BadValue (integer parameter out of range for operation)
  Major opcode of failed request:  132 (XTEST)
  Minor opcode of failed request:  2 (X_XTestFakeInput)
  Value in failed request:  0xb
  Serial number of failed request:  12

And there are mice out there where buttons 11+ can be pressed accidentally,
terminating the synergy client and often leaving the system in a bad state.
