### PR TITLE
Add support for Visual Studio 11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,6 +312,11 @@ else() # not-unix
 		/D_CRT_SECURE_NO_WARNINGS
 		/DVERSION=\"${VERSION}\"
 	)
+
+	# workaround gtest requirement for variadic macros.
+	if (MSVC_VERSION EQUAL 1700)
+		add_definitions( /D_VARIADIC_MAX=10 )
+	endif()
 	
 	if (MSVC_VERSION EQUAL 1600)
 		set(SLN_FILENAME "${CMAKE_CURRENT_BINARY_DIR}/synergy.sln")

--- a/ext/toolchain/commands1.py
+++ b/ext/toolchain/commands1.py
@@ -254,12 +254,14 @@ class InternalCommands:
 	gmockDir = 'gmock-1.6.0'
 
 	win32_generators = {
-		1 : Generator('Visual Studio 10'),
-		2 : Generator('Visual Studio 10 Win64'),
-		3 : Generator('Visual Studio 9 2008'),
-		4 : Generator('Visual Studio 9 2008 Win64'),
-		5 : Generator('Visual Studio 8 2005'),
-		6 : Generator('Visual Studio 8 2005 Win64')
+		1 : Generator('Visual Studio 11'),
+		2 : Generator('Visual Studio 11 Win64'),
+		3 : Generator('Visual Studio 10'),
+		4 : Generator('Visual Studio 10 Win64'),
+		5 : Generator('Visual Studio 9 2008'),
+		6 : Generator('Visual Studio 9 2008 Win64'),
+		7 : Generator('Visual Studio 8 2005'),
+		8 : Generator('Visual Studio 8 2005 Win64')
 	}
 
 	unix_generators = {
@@ -890,7 +892,7 @@ class InternalCommands:
 
 		if generator.startswith('Visual Studio'):
 			# special case for version 10, use new /target:clean
-			if generator.startswith('Visual Studio 10'):
+			if generator.startswith('Visual Studio 10') or generator.startswith('Visual Studio 11'):
 				for target in targets:
 					self.run_vcbuild(generator, target, self.sln_filepath(), '/target:clean')
 				
@@ -1683,6 +1685,8 @@ class InternalCommands:
 			value,type = _winreg.QueryValueEx(key, '9.0')
 		elif generator.startswith('Visual Studio 10'):
 			value,type = _winreg.QueryValueEx(key, '10.0')
+		elif generator.startswith('Visual Studio 11'):
+			value,type = _winreg.QueryValueEx(key, '11.0')
 		else:
 			raise Exception('Cannot determine vcvarsall.bat location for: ' + generator)
 		
@@ -1725,7 +1729,7 @@ class InternalCommands:
 		else:
 			config = 'Debug'
 				
-		if generator.startswith('Visual Studio 10'):
+		if generator.startswith('Visual Studio 10') or generator.startswith('Visual Studio 11'):
 			cmd = ('@echo off\n'
 				'call "%s" %s \n'
 				'cd "%s"\n'

--- a/src/lib/common/common.h
+++ b/src/lib/common/common.h
@@ -92,7 +92,9 @@
 // VC++ specific
 #if (_MSC_VER >= 1200)
 	// work around for statement scoping bug
-#	define for if (false) { } else for
+#	if (_MSC_VER < 1700)
+#		define for if (false) { } else for
+#	endif
 
 	// turn off bonehead warnings
 #	pragma warning(disable: 4786) // identifier truncated in debug info
@@ -137,8 +139,10 @@
 #include <stddef.h>
 
 // if not c++0x, future proof code by allowing use of nullptr
-#ifndef nullptr
-#	define nullptr NULL
+#if !defined( _MSC_VER ) || _MSC_VER < 1700
+#   ifndef nullptr
+#	   define nullptr NULL
+#   endif
 #endif
 
 // make assert available since we use it a lot


### PR DESCRIPTION
Works around various compatibility issues with the newer compiler.

(Just noticed the comment about variadic macros is wrong, it's actually variadic templates, you might want to fix that)