### PR TITLE
Memory leak caused by bad delete in IpcReader

### DIFF
--- a/src/gui/src/IpcReader.cpp
+++ b/src/gui/src/IpcReader.cpp
@@ -65,7 +65,7 @@ void IpcReader::read()
 			char* data = new char[len];
 			readStream(data, len);
 			QString line = QString::fromUtf8(data, len);
-			delete data;
+			delete[] data;
 
 			readLogLine(line);
 		}


### PR DESCRIPTION
src/gui/src/IpcReader.cpp line 68, data is an array of char, but only delete data is called.