### PR TITLE
Fix the build for recent Qt5 versions

### DIFF
--- a/src/gui/src/CommandProcess.h
+++ b/src/gui/src/CommandProcess.h
@@ -18,6 +18,7 @@
 #ifndef COMMANDTHREAD_H
 #define COMMANDTHREAD_H
 
+#include <QObject>
 #include <QStringList>
 
 class CommandProcess : public QObject


### PR DESCRIPTION
This fixes the build for arch linux. The synergy-git package from the Arch User Repository (AUR) refused to build due to a missing #include statement.

See the package here:
https://aur.archlinux.org/packages/synergy-git/
https://aur.archlinux.org/packages/sy/synergy-git/PKGBUILD