### PR TITLE
XWindowsClipboard::m_cacheTime used before being initialized

### DIFF
--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -46,7 +46,8 @@ XWindowsClipboard::XWindowsClipboard(Display* display,
 	m_time(0),
 	m_owner(false),
 	m_timeOwned(0),
-	m_timeLost(0)
+	m_timeLost(0),
+	m_cacheTime(0)
 {
 	// get some atoms
 	m_atomTargets         = XInternAtom(m_display, "TARGETS", False);


### PR DESCRIPTION
XWindowsClipboard::m_cacheTime could be used before being initialized.

It would rarely cause a problem as the uninitialized memory would have to randomly end up matching the new time to be an issue, but it should still be fixed.
