### PR TITLE
Update compile instructions link and improve readme markdown

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Synergy is free and open source (free as in free speech),
 meaning you are free to run it and redistribute it with
 or without changes.
 
-Just use "hm conf" and "hm build" to compile (./hm.sh on
+Just use `hm conf` and `hm build` to compile (`./hm.sh` on
 Linux and Mac).
 
 For detailed compile instructions:

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,6 @@ Just use `hm conf` and `hm build` to compile (`./hm.sh` on
 Linux and Mac).
 
 For detailed compile instructions:
-http://synergy-project.org/wiki/Compiling
+https://github.com/synergy/synergy/wiki/Compiling
 
 Happy hacking!


### PR DESCRIPTION
Hi.
1. Your README file was using markdown but didn't have the markdown `md` extension, so it wasn't rendering as markdown. I changed the name of the README file to README.md, and now github can render it as markdown rather than a text file.
2. Your compiling instructions link has moved and didn't reflect in your README file.