### PR TITLE
Use python2 explicitly if available

### DIFF
--- a/hm.sh
+++ b/hm.sh
@@ -1,3 +1,11 @@
 #! /bin/bash
 
-python hm.py "$@"
+pybin=python
+# Use python2 explicitly if available
+# otherwise things break on arch or any
+# distro that has python3 by default
+py2=$(which python2 2> /dev/null)
+if [ $? = 0 ]; then
+	pybin=$py2
+fi
+$pybin hm.py "$@"

--- a/src/gui/src/CommandProcess.h
+++ b/src/gui/src/CommandProcess.h
@@ -18,6 +18,7 @@
 #ifndef COMMANDTHREAD_H
 #define COMMANDTHREAD_H
 
+#include <QObject>
 #include <QStringList>
 
 class CommandProcess : public QObject


### PR DESCRIPTION
I was trying to build master on arch Linux to debug some latency issues I'm experiencing and I had to do the following adjustments to build it:

* Add QObject include in CommandProcess.h
  This solves compilation error:

  'src/CommandProcess.h:25:2: error: ‘Q_OBJECT’ does not name a type'

  This is probably due to newer Qt version used by arch linux
  The QtObject header seems available at least since Qt 4, if older
  versions need to be supported this could be changed to qobject.h
  depending on the Qt library version detected

* Improve hm.sh to detect if python2 is explicitly available
  and use it to try to avoid using python3, which is unsupported
  by the hm.py script