### PR TITLE
Add a hack for #2765

### DIFF
--- a/src/lib/platform/OSXKeyState.cpp
+++ b/src/lib/platform/OSXKeyState.cpp
@@ -769,6 +769,15 @@ OSXKeyState::getKeyMap(synergy::KeyMap& keyMap,
 			for (std::set<UInt32>::iterator k = required.begin();
 											k != required.end(); ++k) {
 				item.m_required = mapModifiersFromOSX(*k << 8);
+				// Quick and dirty workaround for #2765
+				// #2765 could be due to a bug in the Apple CoreServices
+				// Framework
+				if (item.m_id == 0x20 && item.m_button == 0x7 &&
+						item.m_group == 0) {
+					item.m_button = 0x32;
+					LOG((CLOG_WARN "Key button for 0x20 patched"));
+				}
+
 				keyMap.addKeyEntry(item);
 			}
 		}


### PR DESCRIPTION
I am not a obj C developer and this is definitely not a solution. I couldn’t go any further in my investigation but the problem could be in the Apple CoreServices Framework or in the way Synergy uses it.
Even if this workaround could theoretically break some keyboard layout, it should work for most of them and it could be used while a proper fix is implemented. The current Mac Version of Synergy is not usable so you might want to distribute this workaround (also because it only impacts OsX).
This patch has only been tested on OsX 10.10.5
