### PR TITLE
Fix wrong array deallocation

### DIFF
--- a/src/gui/src/IpcReader.cpp
+++ b/src/gui/src/IpcReader.cpp
@@ -65,7 +65,7 @@ void IpcReader::read()
 			char* data = new char[len];
 			readStream(data, len);
 			QString line = QString::fromUtf8(data, len);
-			delete data;
+			delete [] data;
 
 			readLogLine(line);
 		}


### PR DESCRIPTION
An array is being allocated, so should use the corresponding delete[] operator.