### PR TITLE
Middle click fix

### DIFF
--- a/src/lib/platform/OSXScreen.cpp
+++ b/src/lib/platform/OSXScreen.cpp
@@ -590,7 +590,7 @@ OSXScreen::fakeMouseButton(ButtonID id, bool press)
     
     EMouseButtonState state = press ? kMouseButtonDown : kMouseButtonUp;
     
-    LOG((CLOG_DEBUG1 "faking mouse button id: %d press: %s", id, press ? "pressed" : "released"));
+    LOG((CLOG_DEBUG1 "faking mouse button id: %d press: %s", index, press ? "pressed" : "released"));
     
     MouseButtonEventMapType thisButtonMap = MouseButtonEventMap[index];
     CGEventType type = thisButtonMap[state];

--- a/src/lib/platform/OSXScreen.cpp
+++ b/src/lib/platform/OSXScreen.cpp
@@ -466,8 +466,8 @@ OSXScreen::constructMouseButtonEventMap()
 {
 	const CGEventType source[NumButtonIDs][3] = {
 		{kCGEventLeftMouseUp, kCGEventLeftMouseDragged, kCGEventLeftMouseDown},
-		{kCGEventOtherMouseUp, kCGEventOtherMouseDragged, kCGEventOtherMouseDown},
 		{kCGEventRightMouseUp, kCGEventRightMouseDragged, kCGEventRightMouseDown},
+		{kCGEventOtherMouseUp, kCGEventOtherMouseDragged, kCGEventOtherMouseDown},
 		{kCGEventOtherMouseUp, kCGEventOtherMouseDragged, kCGEventOtherMouseDown},
 		{kCGEventOtherMouseUp, kCGEventOtherMouseDragged, kCGEventOtherMouseDown}
 	};
@@ -541,7 +541,7 @@ void
 OSXScreen::fakeMouseButton(ButtonID id, bool press)
 {
 	// Buttons are indexed from one, but the button down array is indexed from zero
-	UInt32 index = id - kButtonLeft;
+	UInt32 index = mapSynergyButtonToMac(id) - kButtonLeft;
 	if (index >= NumButtonIDs) {
 		return;
 	}
@@ -594,7 +594,7 @@ OSXScreen::fakeMouseButton(ButtonID id, bool press)
     
     MouseButtonEventMapType thisButtonMap = MouseButtonEventMap[index];
     CGEventType type = thisButtonMap[state];
-    
+
     CGEventRef event = CGEventCreateMouseEvent(NULL, type, pos, index);
     
     CGEventSetIntegerValueField(event, kCGMouseEventClickState, m_clickState);
@@ -1441,6 +1441,21 @@ OSXScreen::onHotKey(EventRef event) const
 								HotKeyInfo::alloc(id)));
 
 	return true;
+}
+
+ButtonID
+OSXScreen::mapSynergyButtonToMac(UInt16 button) const
+{
+    switch (button) {
+    case 1:
+        return kButtonLeft;
+    case 2:
+        return kMacButtonMiddle;
+    case 3:
+        return kMacButtonRight;
+    }
+
+    return static_cast<ButtonID>(button);
 }
 
 ButtonID 

--- a/src/lib/platform/OSXScreen.h
+++ b/src/lib/platform/OSXScreen.h
@@ -139,6 +139,9 @@ private:
 	void                hideCursor();
 
 	// map mac mouse button to synergy buttons
+	ButtonID			mapSynergyButtonToMac(UInt16) const;
+
+	// map mac mouse button to synergy buttons
 	ButtonID			mapMacButtonToSynergy(UInt16) const;
 
 	// map mac scroll wheel value to a synergy scroll wheel value

--- a/src/lib/platform/OSXScreen.h
+++ b/src/lib/platform/OSXScreen.h
@@ -138,7 +138,7 @@ private:
 	void                showCursor();
 	void                hideCursor();
 
-	// map mac mouse button to synergy buttons
+	// map synergy mouse button to mac buttons
 	ButtonID			mapSynergyButtonToMac(UInt16) const;
 
 	// map mac mouse button to synergy buttons

--- a/src/lib/synergy/mouse_types.h
+++ b/src/lib/synergy/mouse_types.h
@@ -33,6 +33,9 @@ static const ButtonID	kButtonLeft   = 1;
 static const ButtonID	kButtonMiddle = 2;
 static const ButtonID	kButtonRight  = 3;
 static const ButtonID	kButtonExtra0 = 4;
+
+static const ButtonID   kMacButtonRight = 2;
+static const ButtonID   kMacButtonMiddle = 3;
 //@}
 
 static const UInt8      NumButtonIDs  = 5;


### PR DESCRIPTION
This should fix #2975 by correctly translating incoming mouse events to the proper buttons. Currently whats happening is that when the client received an incoming event for the middle or right mouse buttons, the button ID is incorrect (they are flipped on OSX), but the key mappings are correct, so instead of sending `kCGEventOtherMouse*` events with button index 2 it sends `kCGEventRightMouse*` events.