### PR TITLE
Rephrase MacOS assistive devices warning

### DIFF
--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -156,7 +156,8 @@ bool checkMacAssistiveDevices()
 		QMessageBox::information(
 			NULL, "Synergy",
 			"Please enable access to assistive devices "
-			"(System Preferences), then re-open Synergy.");
+			"System Preferences -> Security & Privacy -> "
+			"Privacy -> Accessibility, then re-open Synergy.");
 	}
 	return result;
 


### PR DESCRIPTION
Just updated warning message for clarify. It took me a little while to figure it out, where to change System Preferences on my Mac
