### PR TITLE
Update link to compile instructions

### DIFF
--- a/README
+++ b/README
@@ -11,6 +11,6 @@ Just use "hm conf" and "hm build" to compile (./hm.sh on
 Linux and Mac).
 
 For detailed compile instructions:
-http://synergy-project.org/wiki/Compiling
+https://github.com/synergy/synergy/wiki/Compiling
 
 Happy hacking!


### PR DESCRIPTION
The old link points to the github Wiki page