### PR TITLE
Don't disconnect on elevation if already elevated

### DIFF
--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -527,7 +527,9 @@ void MainWindow::startSynergy()
 		// is switched; this is because we may need to elevate or not
 		// based on which desk the user is in (login always needs
 		// elevation, where as default desk does not).
-		args << "--stop-on-desk-switch";
+		if (!appConfig().elevateMode()) {
+			args << "--stop-on-desk-switch";
+		}
 #endif
 	}
 


### PR DESCRIPTION
Port the fix from #3241 into the latest codebase to prevent disconnects
due to elevation when already elevated.

This seems to be a hot issue for many users, and I've been successfully using this patch on my old 1.4.x fork for a few years. The code has changed slightly due to some refactoring, so I've ported the patch over to the latest codebase.

It's been working well for me so far -- no disconnects on UAC prompts on clients, and so far no other unintended issues from running elevated all of the time.