### PR TITLE
Fix build with Qt 5.5 by adding #include of <QObject>

### DIFF
--- a/src/gui/src/CommandProcess.h
+++ b/src/gui/src/CommandProcess.h
@@ -18,6 +18,7 @@
 #ifndef COMMANDTHREAD_H
 #define COMMANDTHREAD_H
 
+#include <QObject>
 #include <QStringList>
 
 class CommandProcess : public QObject


### PR DESCRIPTION
I think Qt 5.5 QStringList no longer #includes <QObject> without this synergy fails to build from git on debian linux stretch. With this change it builds again.