### PR TITLE
Fix mouse speed increase with sleep on Mac server

### DIFF
--- a/src/lib/platform/OSXScreen.cpp
+++ b/src/lib/platform/OSXScreen.cpp
@@ -841,6 +841,7 @@ OSXScreen::disable()
 	// FIXME -- stop watching jump zones, stop capturing input
 	
 	if (m_eventTapRLSR) {
+		CFRunLoopRemoveSource(CFRunLoopGetCurrent(), m_eventTapRLSR, kCFRunLoopDefaultMode);
 		CFRelease(m_eventTapRLSR);
 		m_eventTapRLSR = nullptr;
 	}


### PR DESCRIPTION
As reported in #451, with the Mac server, sleeping and resuming (on the server) causes the mouse speed to double on the client upon resume.

Fix by removing the CFRunLoopSource from the run loop on screen disable before releasing it. CFRunLoopAddSource in enable() retains the CFRunLoopSource, so even though the source is released in disable(), the run loop still has a copy. When the server comes out of sleep and the screen is enable()'d, another event tap and run loop source are created and added to the run loop, so the callback is now being called twice for every mouse movement, and so on for every additional time the server sleeps.

This is a better approach than the fix in 267f3ac41f7, because although that fixes the issue by disabling the event tap before the event tap and run loop source are released, a memory leak still occurs since they are retained by the run loop.

Additional references on the behavior of CFRunLoopAddSource:
https://developer.apple.com/library/mac/documentation/CoreFoundation/Reference/CFRunLoopRef/index.html#//apple_ref/c/func/CFRunLoopAddSource
http://www.cocoabuilder.com/archive/cocoa/242438-trouble-with-event-taps.html

I have compiled and verified the fix.

For anyone wishing to verify, I had to make several other changes to get Synergy to compile on El Capitan with Qt 5.5. I've compiled those changes into a single commit 4c7a70b for easy reference, but they should probably be pulled in from their corresponding PRs referenced in that commit.