### PR TITLE
Fix compile warnings

### DIFF
--- a/src/lib/arch/unix/ArchNetworkBSD.cpp
+++ b/src/lib/arch/unix/ArchNetworkBSD.cpp
@@ -332,7 +332,9 @@ ArchNetworkBSD::pollSocket(PollEntry pe[], int num, double timeout)
 		do {
 			ignore = read(unblockPipe[0], dummy, sizeof(dummy));
 		} while (errno != EAGAIN);
-
+		// without ignore there is a warning that the return value of read is ignored
+		// with ignore there is a warning that it is unused, so just "use" it.
+		ignore++;
 		// don't count this unblock pipe in return value
 		--n;
 	}
@@ -505,6 +507,9 @@ ArchNetworkBSD::unblockPollSocket(ArchThread thread)
 		int ignore;
 
 		ignore = write(unblockPipe[1], &dummy, 1);
+		// without ignore there is a warning that the return value of read is ignored
+		// with ignore there is a warning that it is unused, so just "use" it.
+		ignore++;
 	}
 }
 

--- a/src/lib/platform/XWindowsEventQueueBuffer.cpp
+++ b/src/lib/platform/XWindowsEventQueueBuffer.cpp
@@ -54,10 +54,10 @@ class EventQueueTimer { };
 
 XWindowsEventQueueBuffer::XWindowsEventQueueBuffer(
 		Display* display, Window window, IEventQueue* events) :
-	m_events(events),
 	m_display(display),
 	m_window(window),
-	m_waiting(false)
+	m_waiting(false),
+	m_events(events)
 {
 	assert(m_display != NULL);
 	assert(m_window  != None);

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -96,6 +96,7 @@ XWindowsScreen::XWindowsScreen(
 		bool disableXInitThreads,
 		int mouseScrollDelta,
 		IEventQueue* events) :
+	PlatformScreen(events),
 	m_isPrimary(isPrimary),
 	m_mouseScrollDelta(mouseScrollDelta),
 	m_display(NULL),
@@ -120,8 +121,7 @@ XWindowsScreen::XWindowsScreen(
 	m_xkb(false),
 	m_xi2detected(false),
 	m_xrandr(false),
-	m_events(events),
-	PlatformScreen(events)
+	m_events(events)
 {
 	assert(s_screen == NULL);
 
@@ -1272,7 +1272,6 @@ XWindowsScreen::handleSystemEvent(const Event& event, void*)
 				cookie->extension == xi_opcode) {
 			if (cookie->evtype == XI_RawMotion) {
 				// Get current pointer's position
-				Window root, child;
 				XMotionEvent xmotion;
 				xmotion.type = MotionNotify;
 				xmotion.send_event = False; // Raw motion

--- a/src/lib/plugin/ns/SecureSocket.cpp
+++ b/src/lib/plugin/ns/SecureSocket.cpp
@@ -545,7 +545,7 @@ bool
 SecureSocket::verifyCertFingerprint()
 {
 	// calculate received certificate fingerprint
-	X509 *cert = cert = SSL_get_peer_certificate(m_ssl->m_ssl);
+	X509 *cert = SSL_get_peer_certificate(m_ssl->m_ssl);
 	EVP_MD* tempDigest;
 	unsigned char tempFingerprint[EVP_MAX_MD_SIZE];
 	unsigned int tempFingerprintLen;

--- a/src/lib/synergy/ArgsBase.cpp
+++ b/src/lib/synergy/ArgsBase.cpp
@@ -21,14 +21,8 @@
 ArgsBase::ArgsBase() :
 #if SYSAPI_WIN32
 m_daemon(false), // daemon mode not supported on windows (use --service)
-m_debugServiceWait(false),
-m_pauseOnExit(false),
-m_stopOnDeskSwitch(false),
 #else
 m_daemon(true), // backward compatibility for unix (daemon by default)
-#endif
-#if WINAPI_XWINDOWS
-m_disableXInitThreads(false),
 #endif
 m_backend(false),
 m_restartable(true),
@@ -40,6 +34,14 @@ m_display(NULL),
 m_disableTray(false),
 m_enableIpc(false),
 m_enableDragDrop(false),
+#if SYSAPI_WIN32
+m_debugServiceWait(false),
+m_pauseOnExit(false),
+m_stopOnDeskSwitch(false),
+#endif
+#if WINAPI_XWINDOWS
+m_disableXInitThreads(false),
+#endif
 m_shouldExit(false),
 m_synergyAddress(),
 m_enableCrypto(false),


### PR DESCRIPTION
Warnings were
- unused variables: Just "use" it
- members initialized in wrong order: reorder them
- variable used twice in initialisation: remove one occurrence
