### PR TITLE
Add "--enable-crypto" to "HELP_COMMON_INFO_1" DEFINE

### DIFF
--- a/src/lib/synergy/App.h
+++ b/src/lib/synergy/App.h
@@ -163,7 +163,8 @@ private:
 	"*     --restart            restart the server automatically if it fails.\n" \
 	"  -l  --log <file>         write log messages to file.\n" \
 	"      --no-tray            disable the system tray icon.\n" \
-	"      --enable-drag-drop   enable file drag & drop.\n"
+	"      --enable-drag-drop   enable file drag & drop.\n"\
+	"	--enable-crypto     enables SSL encryption.\n"
 
 #define HELP_COMMON_INFO_2 \
 	"  -h, --help               display this help and exit.\n" \


### PR DESCRIPTION
added "--enable-crypto" to the "HELP_COMMON_INFO_1" Define, so users can find this command parameter as it is not documented anywhere else.
I had to put in an issue request to find it my self.