### PR TITLE
Fix hm.sh to prefer python2 if available

### DIFF
--- a/hm.sh
+++ b/hm.sh
@@ -1,3 +1,11 @@
 #! /bin/bash
 
-python hm.py "$@"
+pybin=python
+# Use python2 explicitly if available
+# otherwise things break on arch or any
+# distro that has python3 by default
+py2=$(which python2 2> /dev/null)
+if [ $? = 0 ]; then
+	pybin=$py2
+fi
+$pybin hm.py "$@"


### PR DESCRIPTION
The build scripts only support python2 at the moment
and distributions that already switched to python3
require explicit use of python2 when using hm.sh
