### PR TITLE
Added support for precise screen positioning

### DIFF
--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -2088,11 +2088,11 @@ ConfigReadContext::parseInterval(const ArgList& args) const
 	}
 
 	char* end;
-	long startValue = strtol(args[0].c_str(), &end, 10);
+	double startValue = strtod(args[0].c_str(), &end);
 	if (end[0] != '\0') {
 		throw XConfigRead(*this, "invalid interval \"%{1}\"", concatArgs(args));
 	}
-	long endValue = strtol(args[1].c_str(), &end, 10);
+	double endValue = strtod(args[1].c_str(), &end);
 	if (end[0] != '\0') {
 		throw XConfigRead(*this, "invalid interval \"%{1}\"", concatArgs(args));
 	}


### PR DESCRIPTION
My monitor setup consists six monitors, all the same size. The three top monitors are connected to a Raspberry Pi each. The bottom monitors are connected to my workstation. For the Synergy setup to work properly I'd needed to enter values like 33.33333333 and 66.66666667. When entering them rounded as 33 and 67, the cursor makes annoying jumps at the monitor corners. To fix this I added support for using floating point values to specify the range instead of integers.
