### PR TITLE
Fix muti imes issue in Windows OS,

### DIFF
--- a/src/lib/platform/MSWindowsKeyState.cpp
+++ b/src/lib/platform/MSWindowsKeyState.cpp
@@ -1077,7 +1077,7 @@ MSWindowsKeyState::getKeyMap(synergy::KeyMap& keyMap)
 		}
 
 		// set virtual key to button table
-		if (GetKeyboardLayout(0) == m_groups[g]) {
+		if (activeLayout == m_groups[g]) {
 			for (KeyButton i = 0; i < 512; ++i) {
 				if (m_buttonToVK[i] != 0) {
 					if (m_virtualKeyToButton[m_buttonToVK[i]] == 0) {


### PR DESCRIPTION
virtaual key table is mapped for all IMEs not just active IME.

And this cause wrong modifier key pressed issue.

For example, if I use Korean and Japanese IMEs,
pressing hangul key makes alt key pressed.
So when I press just 'a', client interpretes that 'alt-a'.
