### PR TITLE
add missing dll (libgcc_s_dw2-1.dll)

### DIFF
--- a/src/setup/win32/Product.wxs
+++ b/src/setup/win32/Product.wxs
@@ -122,6 +122,7 @@
         </File>
 
         <?if 5 = $(var.QtMajor) ?>
+          <File Source="$(var.QtPath)\libgcc_s_dw2-1.dll" />
           <File Source="$(var.QtPath)\Qt5Core.dll" />
           <File Source="$(var.QtPath)\Qt5Gui.dll" />
           <File Source="$(var.QtPath)\Qt5Network.dll" />


### PR DESCRIPTION
Removing libgcc_s_dw2-1.dll causes missing DLL error.
I added it back to Product.wxs