### PR TITLE
Throw exception if we could not find git, fix typo, zeroconf standards compliance

### DIFF
--- a/ext/toolchain/commands1.py
+++ b/ext/toolchain/commands1.py
@@ -950,11 +950,14 @@ class InternalCommands:
 		if sys.version_info < (2, 4):
 			raise Exception("Python 2.4 or greater required.")
 
-		p = subprocess.Popen(
-			["git", "log", "--pretty=format:%h", "-n", "1"],
-			stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+		try:
+		    p = subprocess.Popen(
+			    ["git", "log", "--pretty=format:%h", "-n", "1"],
+			    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-		stdout, stderr = p.communicate()
+		    stdout, stderr = p.communicate()
+		except OSError:
+			raise Exception('Could not run git')
 
 		if p.returncode != 0:
 			raise Exception('Could not get revision, git error: ' + str(p.returncode))

--- a/ext/toolchain/commands1.py
+++ b/ext/toolchain/commands1.py
@@ -306,7 +306,7 @@ class InternalCommands:
 			'  genlist     Shows the list of available platform generators\n'
 			'  usage       Shows the help screen\n'
 			'\n'
-			'Example: %s build -g 3'
+			'Example: %s conf -g 3'
 			) % (app, app)
 
 	def configureAll(self, targets, extraArgs=''):

--- a/src/gui/src/ZeroconfService.cpp
+++ b/src/gui/src/ZeroconfService.cpp
@@ -33,8 +33,8 @@ static const QStringList preferedIPAddress(
 				"10." <<
 				"172.");
 
-const char* ZeroconfService:: m_ServerServiceName = "_synergyServerZeroconf._tcp";
-const char* ZeroconfService:: m_ClientServiceName = "_synergyClientZeroconf._tcp";
+const char* ZeroconfService:: m_ServerServiceName = "_synergyServer._tcp";
+const char* ZeroconfService:: m_ClientServiceName = "_synergyClient._tcp";
 
 ZeroconfService::ZeroconfService(MainWindow* mainWindow) :
 	m_pMainWindow(mainWindow),

--- a/src/lib/base/Log.cpp
+++ b/src/lib/base/Log.cpp
@@ -180,7 +180,7 @@ Log::print(const char* file, int line, const char* fmt, ...)
 		sprintf(timestamp, "%04i-%02i-%02iT%02i:%02i:%02i", tm->tm_year + 1900, tm->tm_mon+1, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec);
 
 		// square brackets, spaces, comma and null terminator take about 10
-		int size = 10;
+		size_t size = 10;
 		size += strlen(timestamp);
 		size += strlen(g_priority[priority]);
 		size += strlen(buffer);

--- a/src/lib/net/TCPSocket.cpp
+++ b/src/lib/net/TCPSocket.cpp
@@ -328,7 +328,7 @@ TCPSocket::doRead()
 {
 	UInt8 buffer[4096];
 	memset(buffer, 0, sizeof(buffer));
-	size_t bytesRead = 0;
+	int bytesRead = 0;
 	
 	bytesRead = (int) ARCH->readSocket(m_socket, buffer, sizeof(buffer));
 	
@@ -339,7 +339,7 @@ TCPSocket::doRead()
 		do {
 			m_inputBuffer.write(buffer, bytesRead);
 
-			bytesRead = ARCH->readSocket(m_socket, buffer, sizeof(buffer));
+			bytesRead = (int) ARCH->readSocket(m_socket, buffer, sizeof(buffer));
 		} while (bytesRead > 0);
 		
 		// send input ready if input buffer was empty

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -349,7 +349,7 @@ MSWindowsScreen::leave()
 		// warp to center
 		LOG((CLOG_DEBUG1 "warping cursor to center: %+d, %+d", m_xCenter, m_yCenter));
 		float dpi = DpiHelper::getDpi();
-		warpCursor(m_xCenter / dpi, m_yCenter / dpi);
+		warpCursor((int)(m_xCenter / dpi), (int)(m_yCenter / dpi));
 
 		// disable special key sequences on win95 family
 		enableSpecialKeys(false);
@@ -1416,7 +1416,7 @@ MSWindowsScreen::onMouseMove(SInt32 mx, SInt32 my)
 		// secondary screen.
 		LOG((CLOG_DEBUG5 "warping server cursor to center: %+d,%+d", m_xCenter, m_yCenter));
 		float dpi = DpiHelper::getDpi();
-		warpCursorNoFlush(m_xCenter / dpi, m_yCenter / dpi);
+		warpCursorNoFlush((int)(m_xCenter / dpi), (int)(m_yCenter / dpi));
 		
 		// examine the motion.  if it's about the distance
 		// from the center of the screen to an edge then


### PR DESCRIPTION
commit 255a32db9cfa4d6b2c21bb32b2a7b31446a07a69
Author: Nye Liu nyet@nyet.org
Date:   Thu Oct 20 14:03:37 2016 -0700

```
Throw exception if we could not find git
```

commit 137b254b332d582dbe380b0d5197dbc78ab6024c
Author: Nye Liu nyet@nyet.org
Date:   Wed Sep 28 10:19:29 2016 -0700

```
Fix typo in commands1.py
```

commit 2bff5d0a16ba333a9b956cc9cc978aa95346a4ca
Author: Nye Liu nyet@nyet.org
Date:   Tue Sep 1 17:41:37 2015 -0700

```
Bug #4991: Application protocol name must be underscore plus 1-15 characters. See <http://www.dns-sd.org/ServiceTypes.html>
```
