### PR TITLE
XRandR: fix screen size calculation

### DIFF
--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -974,22 +974,6 @@ XWindowsScreen::saveShape()
 	m_w = WidthOfScreen(DefaultScreenOfDisplay(m_display));
 	m_h = HeightOfScreen(DefaultScreenOfDisplay(m_display));
 
-#if HAVE_X11_EXTENSIONS_XRANDR_H
-	if (m_xrandr){
-	  int numSizes;
-	  XRRScreenSize* xrrs;
-	  Rotation rotation;
-	  xrrs = XRRSizes(m_display, DefaultScreen(m_display), &numSizes);
-	  XRRRotations(m_display, DefaultScreen(m_display), &rotation);
-	  if (xrrs != NULL) {
-	    if (rotation & (RR_Rotate_90|RR_Rotate_270) ){
-	      m_w = xrrs->height;
-	      m_h = xrrs->width;
-	    }
-	  }
-	}
-#endif
-
 	// get center of default screen
 	m_xCenter = m_x + (m_w >> 1);
 	m_yCenter = m_y + (m_h >> 1);


### PR DESCRIPTION
XWindowsScreen::saveShape() using XRRSizes / XRRRotations to
calculate screen dimensions when XRandR and a rotated screen
was detected. This is wrong. The screen dimensions in the
display properties already reflect rotation.

Moreover, on servers supporting XRandR >= 1.2, the XRRSizes()
and XRRRotations calls from XRandR 1.1 will return the
properties of the "primary output" in XRandR 1.2 terms rather than
the properties of the entire screen.