### PR TITLE
Fix for Issue #5648 - Mouse Drifting/Jittering/Lagging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ if (UNIX)
 
 	# warnings as errors:
 	# we have a problem with people checking in code with warnings.
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wno-unused-local-typedef")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wno-unused-local-typedefs")
 
 	if (NOT APPLE)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+v1.8.7-stable
+=============
+Bug #5784 - Edition changes when reopening GUI
+
 v1.8.6-stable
 =============
 Bug #5592 - Some keys don't work for macOS Sierra clients

--- a/src/test/unittests/synergy/ClipboardChunkTests.cpp
+++ b/src/test/unittests/synergy/ClipboardChunkTests.cpp
@@ -26,9 +26,11 @@ TEST(ClipboardChunkTests, start_formatStartChunk)
 	UInt32 sequence = 0;
 	String mockDataSize("10");
 	ClipboardChunk* chunk = ClipboardChunk::start(id, sequence, mockDataSize);
+	UInt32 temp_m_chunk;
+	memcpy(&temp_m_chunk, &(chunk->m_chunk[1]), 4);
 
 	EXPECT_EQ(id, chunk->m_chunk[0]);
-	EXPECT_EQ(sequence, (UInt32)chunk->m_chunk[1]);
+	EXPECT_EQ(sequence, temp_m_chunk);
 	EXPECT_EQ(kDataStart, chunk->m_chunk[5]);
 	EXPECT_EQ('1', chunk->m_chunk[6]);
 	EXPECT_EQ('0', chunk->m_chunk[7]);
@@ -43,9 +45,11 @@ TEST(ClipboardChunkTests, data_formatDataChunk)
 	UInt32 sequence = 1;
 	String mockData("mock data");
 	ClipboardChunk* chunk = ClipboardChunk::data(id, sequence, mockData);
+	UInt32 temp_m_chunk;
+	memcpy(&temp_m_chunk, &(chunk->m_chunk[1]), 4);
 
 	EXPECT_EQ(id, chunk->m_chunk[0]);
-	EXPECT_EQ(sequence, (UInt32)chunk->m_chunk[1]);
+	EXPECT_EQ(sequence, temp_m_chunk);
 	EXPECT_EQ(kDataChunk, chunk->m_chunk[5]);
 	EXPECT_EQ('m', chunk->m_chunk[6]);
 	EXPECT_EQ('o', chunk->m_chunk[7]);
@@ -66,9 +70,11 @@ TEST(ClipboardChunkTests, end_formatDataChunk)
 	ClipboardID id = 1;
 	UInt32 sequence = 1;
 	ClipboardChunk* chunk = ClipboardChunk::end(id, sequence);
+	UInt32 temp_m_chunk;
+	memcpy(&temp_m_chunk, &(chunk->m_chunk[1]), 4);
 
 	EXPECT_EQ(id, chunk->m_chunk[0]);
-	EXPECT_EQ(sequence, (UInt32)chunk->m_chunk[1]);
+	EXPECT_EQ(sequence, temp_m_chunk);
 	EXPECT_EQ(kDataEnd, chunk->m_chunk[5]);
 	EXPECT_EQ('\0', chunk->m_chunk[6]);
 


### PR DESCRIPTION
Fix for Issue #5648, using proposed code from @PutzWorks. Also includes compilation fixes to allow compiling on Sierra (unfortunately, I was only able to implement the fix with QT4). Tested on my two Macs, both of which were exhibiting the mouse problem, and are now no longer exhibiting the problem with this new build.