### PR TITLE
Server omits client connections in ｄestructors

### DIFF
--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -251,7 +251,7 @@ Server::~Server()
 	// force immediate disconnection of secondary clients
 	disconnect();
 	for (OldClients::iterator index = m_oldClients.begin();
-							index != m_oldClients.begin(); ++index) {
+							index != m_oldClients.end(); ++index) {
 		BaseClientProxy* client = index->first;
 		m_events->deleteTimer(index->second);
 		m_events->removeHandler(Event::kTimer, client);


### PR DESCRIPTION
We have found and fixed a bug using PVS-Studio tool. [PVS-Studio](https://www.viva64.com/en/pvs-studio/) is a static code analyzer for C, C++ and C#.

We suggests having a look at the emails, sent from @pvs-studio.com.

Analyzer warning: [V625](https://www.viva64.com/en/w/V625/) Consider inspecting the 'for' operator. Initial and final values of the iterator are the same. Server.cpp 253