### PR TITLE
Fix icon path on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,7 +406,7 @@ endif()
 #
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     configure_files (${CMAKE_CURRENT_SOURCE_DIR}/dist/rpm ${CMAKE_BINARY_DIR}/rpm)
-    install(FILES res/synergy.svg DESTINATION share/icons)
+    install(FILES res/synergy.svg DESTINATION share/icons/hicolor/scalable/apps)
     if("${VERSION_MAJOR}" STREQUAL "2") 
         install(FILES res/synergy2.desktop DESTINATION share/applications)
     else()

--- a/dist/rpm/synergy.spec.in
+++ b/dist/rpm/synergy.spec.in
@@ -20,7 +20,7 @@ Work seamlessly across Windows, macOS and Linux.
 %{_bindir}/synergys
 %{_bindir}/syntool
 %attr(644,-,-) %{_datarootdir}/applications/synergy.desktop
-%attr(644,-,-) %{_datarootdir}/icons/synergy.svg
+%attr(644,-,-) %{_datarootdir}/icons/hicolor/scalable/apps/synergy.svg
 
 %changelog
 * Wed Apr 26 2017 Symless <engineering@symless.com>

--- a/res/synergy.desktop
+++ b/res/synergy.desktop
@@ -5,7 +5,7 @@ Name=Synergy
 Comment=Keyboard and mouse sharing solution
 Path=/usr/bin
 Exec=/usr/bin/synergy
-Icon=/usr/share/icons/synergy.svg
+Icon=synergy
 Terminal=false
 Categories=Network;
 

--- a/res/synergy2.desktop
+++ b/res/synergy2.desktop
@@ -5,7 +5,7 @@ Name=Synergy
 Comment=Keyboard and mouse sharing solution
 Path=/usr/bin
 Exec=/usr/bin/synergy2
-Icon=/usr/share/icons/synergy.svg
+Icon=synergy
 Terminal=false
 Categories=Network;
 


### PR DESCRIPTION
The current icon path on Linux is preventing themes from providing their own icons for synergy.

.desktop files should generally avoid providing absolute icon paths when possible and instead simply adhere to [these conventions](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html#directory_layout).

Let me know if you need any more information, if you'd like me to change target branch, etc.

Thanks