### PR TITLE
Use EI screen when `XDG_SESSION_TYPE` is "wayland"

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ Enhancements:
 - #7448 Only add PR comments for internal PR
 - #7445 Update `config.yaml` to support Linux Mint build target
 - #7453 Change default value for dev thanks message
+- #7455 Use EI screen when XDG_SESSION_TYPE is "wayland"
 
 # 1.15.0
 

--- a/src/lib/platform/wayland.h
+++ b/src/lib/platform/wayland.h
@@ -1,0 +1,29 @@
+/*
+ * synergy -- mouse and keyboard sharing utility
+ * Copyright (C) 2024 Symless Ltd.
+ *
+ * This package is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * found in the file LICENSE that should have accompanied this file.
+ *
+ * This package is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace synergy::platform {
+
+inline bool isWayland() {
+  const std::string session = getenv("XDG_SESSION_TYPE");
+  return session == "wayland";
+}
+
+} // namespace synergy::platform

--- a/src/lib/synergy/App.h
+++ b/src/lib/synergy/App.h
@@ -219,17 +219,7 @@ private:
   "                             reading error messages that occur on exit.\n"
 #endif
 
-#if WINAPI_LIBEI
-
-const auto kNoWaylandEiArg =
-    "      --no-wayland-ei      do not use EI (emulated input) for\n"
-    "                             Wayland and instead use the legacy\n"
-    "                             X Window System.\n";
-const auto kHelpNoWayland = "";
-
-#elif WINAPI_XWINDOWS
-
-const auto kNoWaylandEiArg = "";
+#if !defined(WINAPI_LIBEI) && WINAPI_XWINDOWS
 const auto kHelpNoWayland =
     "\n"
     "Your Linux distribution does not support Wayland EI (emulated input)\n"
@@ -237,6 +227,5 @@ const auto kHelpNoWayland =
     "that supports Wayland EI.\n";
 
 #else
-const auto kNoWaylandEiArg = "";
 const auto kHelpNoWayland = "";
 #endif

--- a/src/lib/synergy/ArgParser.cpp
+++ b/src/lib/synergy/ArgParser.cpp
@@ -165,16 +165,6 @@ bool ArgParser::parsePlatformArgs(
     argsBase.m_disableXInitThreads = true;
   }
 
-#if WINAPI_LIBEI
-  else if (isArg(i, argc, argv, nullptr, "--no-wayland-ei")) {
-    argsBase.m_disableWaylandEi = true;
-  }
-
-  else if (!isServer && isArg(i, argc, argv, nullptr, "--no-wayland-portal")) {
-    argsBase.m_disableWaylandPortal = true;
-  }
-#endif
-
   else {
     // option not supported here
     return false;

--- a/src/lib/synergy/ArgsBase.h
+++ b/src/lib/synergy/ArgsBase.h
@@ -21,18 +21,6 @@
 
 namespace synergy {
 
-#if WINAPI_LIBEI
-const auto kDisableEiDefault = false;
-#else
-const auto kDisableEiDefault = true;
-#endif
-
-#if WINAPI_LIBPORTAL
-const auto kDisablePortalDefault = false;
-#else
-const auto kDisablePortalDefault = true;
-#endif
-
 /**
  * @brief This is the base Argument class that will store the generic
  *        arguments passed into the applications this will be derived
@@ -105,12 +93,6 @@ public:
 
   /// @brief Stop this computer from sleeping
   bool m_preventSleep = false;
-
-  /// @brief Disable EI (Emulated Input) for Wayland support
-  bool m_disableWaylandEi = kDisableEiDefault;
-
-  /// @brief Disable Portal for Wayland support (use EI sockets instead)
-  bool m_disableWaylandPortal = kDisablePortalDefault;
 
 #if SYSAPI_WIN32
   bool m_debugServiceWait = false;

--- a/src/lib/synergy/ClientApp.cpp
+++ b/src/lib/synergy/ClientApp.cpp
@@ -184,11 +184,13 @@ synergy::Screen *ClientApp::createScreen() {
 #endif
 #if WINAPI_LIBEI
   if (synergy::platform::isWayland()) {
+    LOG((CLOG_INFO "using ei screen for wayland"));
     return new synergy::Screen(
         new synergy::EiScreen(false, m_events, true), m_events);
   }
 #endif
 #if WINAPI_XWINDOWS
+  LOG((CLOG_INFO "using legacy x windows screen"));
   return new synergy::Screen(
       new XWindowsScreen(
           args().m_display, false, args().m_disableXInitThreads,

--- a/src/lib/synergy/ClientApp.cpp
+++ b/src/lib/synergy/ClientApp.cpp
@@ -36,6 +36,7 @@
 #include "net/SocketMultiplexer.h"
 #include "net/TCPSocketFactory.h"
 #include "net/XSocket.h"
+#include "platform/wayland.h"
 #include "synergy/ArgParser.h"
 #include "synergy/ClientArgs.h"
 #include "synergy/Screen.h"
@@ -139,15 +140,9 @@ void ClientApp::help() {
       << "      --host               act as a host; invert server/client mode\n"
       << "                             and listen instead of connecting.\n"
 #if WINAPI_XWINDOWS
-      << "      --display <display>  connect to the X server at <display>\n"
+      << "      --display <display>  when in X mode, connect to the X server\n"
+      << "                             at <display>\n."
       << "      --no-xinitthreads    do not call XInitThreads()\n"
-#endif
-#if defined(WINAPI_XWINDOWS) && defined(WINAPI_LIBEI)
-      << kNoWaylandEiArg
-#endif
-#if defined(WINAPI_LIBPORTAL) && defined(WINAPI_LIBEI)
-      << "      --no-wayland-portal  do not use Portal for Wayland and \n"
-      << "                             connect to EI socket instead.\n"
 #endif
       << HELP_COMMON_INFO_2 << "\n"
       << "* marks defaults.\n"
@@ -188,10 +183,9 @@ synergy::Screen *ClientApp::createScreen() {
       m_events);
 #endif
 #if WINAPI_LIBEI
-  if (!args().m_disableWaylandEi) {
+  if (synergy::platform::isWayland()) {
     return new synergy::Screen(
-        new synergy::EiScreen(false, m_events, !args().m_disableWaylandPortal),
-        m_events);
+        new synergy::EiScreen(false, m_events, true), m_events);
   }
 #endif
 #if WINAPI_XWINDOWS

--- a/src/lib/synergy/ServerApp.cpp
+++ b/src/lib/synergy/ServerApp.cpp
@@ -32,6 +32,7 @@
 #include "net/SocketMultiplexer.h"
 #include "net/TCPSocketFactory.h"
 #include "net/XSocket.h"
+#include "platform/wayland.h"
 #include "server/ClientListener.h"
 #include "server/ClientProxy.h"
 #include "server/PrimaryClient.h"
@@ -139,12 +140,9 @@ void ServerApp::help() {
       << "instead.\n" HELP_COMMON_INFO_1
 
 #if WINAPI_XWINDOWS
-      << "      --display <display>  connect to the X server at <display>\n"
+      << "      --display <display>  when in X mode, connect to the X server\n"
+      << "                             at <display>\n."
       << "      --no-xinitthreads    do not call XInitThreads()\n"
-#endif
-
-#if defined(WINAPI_XWINDOWS) && defined(WINAPI_LIBEI)
-      << kNoWaylandEiArg
 #endif
 
       << HELP_SYS_INFO HELP_COMMON_INFO_2 "\n"
@@ -552,10 +550,9 @@ synergy::Screen *ServerApp::createScreen() {
 #endif
 
 #if WINAPI_LIBEI
-  if (!args().m_disableWaylandEi) {
+  if (synergy::platform::isWayland()) {
     return new synergy::Screen(
-        new synergy::EiScreen(true, m_events, !args().m_disableWaylandPortal),
-        m_events);
+        new synergy::EiScreen(true, m_events, true), m_events);
   }
 #endif
 

--- a/src/lib/synergy/ServerApp.cpp
+++ b/src/lib/synergy/ServerApp.cpp
@@ -551,12 +551,14 @@ synergy::Screen *ServerApp::createScreen() {
 
 #if WINAPI_LIBEI
   if (synergy::platform::isWayland()) {
+    LOG((CLOG_INFO "using ei screen for wayland"));
     return new synergy::Screen(
         new synergy::EiScreen(true, m_events, true), m_events);
   }
 #endif
 
 #if WINAPI_XWINDOWS
+  LOG((CLOG_INFO "using legacy x windows screen"));
   return new synergy::Screen(
       new XWindowsScreen(
           args().m_display, true, args().m_disableXInitThreads, 0, m_events),


### PR DESCRIPTION
https://symless.atlassian.net/browse/S1-1822