### PR TITLE
Only create tags (not releases) when merging PRs into master

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -38,13 +38,15 @@ jobs:
       - name: Print next version
         run: echo ${{ steps.next-version.outputs.next-version }}
 
-      - name: Create release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.ORGANIZATION_TOKEN }}
+      - name: Create git tag
+        uses: actions/github-script@v7
         with:
-          tag_name: ${{ steps.next-version.outputs.next-version }}
-          release_name: ${{ steps.next-version.outputs.next-version }}
-          draft: false
-          prerelease: ${{ !startsWith(github.ref, 'refs/heads/release') }}
+          script: |
+            const ref = `refs/tags/${{ steps.next-version.outputs.next-version }}`;
+            const sha = context.sha;
+            await github.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: ref,
+              sha: sha,
+            });

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -8,8 +8,8 @@ on:
       - release/**
 
 jobs:
-  create-release:
-    if: ${{ vars.CREATE_RELEASE }}
+  create-tag:
+    if: ${{ vars.CREATE_TAGS }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -34,9 +34,6 @@ jobs:
         with:
           current-version: ${{ env.CURRENT_VERSION }}
           override-stage: ${{ env.OVERRIDE_STAGE }}
-
-      - name: Print next version
-        run: echo ${{ steps.next-version.outputs.next-version }}
 
       - name: Create git tag
         uses: actions/github-script@v7


### PR DESCRIPTION
https://symless.atlassian.net/browse/S1-1801

> When people in the community want to see [releases](https://github.com/symless/synergy-core/releases) in a GitHub project, they do not expect to see each merge into main/master as a release; it’s confusing when you observe a series of “pre-release” snapshots that are not real releases. It also makes finding actual releases difficult and frustrating.

> Only create tags for each revision. We should create releases from an actual release branch. For instance, if we merge a PR into main/master, it should make a tag (not a release) and when we push to a branch beginning in release then it should create a release. 

> Important: We should also delete all releases that are pre-releases (under the assumption they are not actual releases); this should be automated and not done manually.