### PR TITLE
Option to link against local `libportal` and other subprojects

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,7 @@ Enhancements:
 - #7464 Restore `--only-python` arg to only install Python deps
 - #7465 Also cut `+` char for `SHORT_VERSION` var used on upload
 - #7467 Load server or client args from `synergy-config.toml`
+- #7469 Option to link against local libportal and other subprojects
 
 # 1.15.1
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -11,7 +11,7 @@ Enhancements:
 - #7464 Restore `--only-python` arg to only install Python deps
 - #7465 Also cut `+` char for `SHORT_VERSION` var used on upload
 - #7467 Load server or client args from `synergy-config.toml`
-- #7469 Option to link against local libportal and other subprojects
+- #7469 Option to link against local `libportal` and other subprojects
 
 # 1.15.1
 

--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -169,29 +169,61 @@ macro(configure_wayland_libs)
 
   include(FindPkgConfig)
 
-  pkg_check_modules(LIBEI QUIET "libei-1.0 >= ${LIBEI_MIN_VERSION}")
-  if(LIBEI_FOUND)
-    message(STATUS "libei version: ${LIBEI_VERSION}")
-    add_definitions(-DWINAPI_LIBEI=1)
-    include_directories(${LIBEI_INCLUDE_DIRS})
+  option(SYSTEM_LIBEI "Use system libei" ON)
+  if(SYSTEM_LIBEI)
+    pkg_check_modules(LIBEI QUIET "libei-1.0 >= ${LIBEI_MIN_VERSION}")
+    if(LIBEI_FOUND)
+      message(STATUS "libei version: ${LIBEI_VERSION}")
+      add_definitions(-DWINAPI_LIBEI=1)
+      include_directories(${LIBEI_INCLUDE_DIRS})
+    else()
+      message(WARNING "libei >= ${LIBEI_MIN_VERSION} not found")
+    endif()
   else()
-    message(
-      WARNING
-        "libei >= ${LIBEI_MIN_VERSION} not found, Wayland support will be disabled."
-    )
+    set(libei_bin_dir ${CMAKE_BINARY_DIR}/meson/subprojects/libei)
+    set(libei_src_dir ${CMAKE_SOURCE_DIR}/subprojects/libei)
+    find_library(
+      LIBEI_LINK_LIBRARIES
+      NAMES ei
+      PATHS ${libei_bin_dir}/src
+      NO_DEFAULT_PATH)
+    if(LIBEI_LINK_LIBRARIES)
+      message(STATUS "Using local subproject libei")
+      set(LIBEI_FOUND true)
+      add_definitions(-DWINAPI_LIBEI=1)
+      include_directories(${libei_src_dir}/src)
+    else()
+      message(WARNING "Local libei not found")
+    endif()
   endif()
 
-  pkg_check_modules(LIBPORTAL QUIET "libportal >= ${LIBPORTAL_MIN_VERSION}")
-  if(LIBPORTAL_FOUND)
-    message(STATUS "libportal version: ${LIBPORTAL_VERSION}")
-    add_definitions(-DWINAPI_LIBPORTAL=1)
-    include_directories(${LIBPORTAL_INCLUDE_DIRS})
-    check_libportal()
+  option(SYSTEM_LIBPORTAL "Use system libportal" ON)
+  if(SYSTEM_LIBPORTAL)
+    pkg_check_modules(LIBPORTAL QUIET "libportal >= ${LIBPORTAL_MIN_VERSION}")
+    if(LIBPORTAL_FOUND)
+      message(STATUS "libportal version: ${LIBPORTAL_VERSION}")
+      add_definitions(-DWINAPI_LIBPORTAL=1)
+      include_directories(${LIBPORTAL_INCLUDE_DIRS})
+      check_libportal()
+    else()
+      message(WARNING "libportal >= ${LIBPORTAL_MIN_VERSION} not found")
+    endif()
   else()
-    message(
-      WARNING
-        "libportal >= ${LIBPORTAL_MIN_VERSION} not found, some Wayland features will be disabled."
-    )
+    set(libportal_bin_dir ${CMAKE_BINARY_DIR}/meson/subprojects/libportal)
+    set(libportal_src_dir ${CMAKE_SOURCE_DIR}/subprojects/libportal)
+    find_library(
+      LIBPORTAL_LINK_LIBRARIES
+      NAMES portal
+      PATHS ${libportal_bin_dir}/libportal
+      NO_DEFAULT_PATH)
+    if(LIBPORTAL_LINK_LIBRARIES)
+      message(STATUS "Using local subproject libportal")
+      set(LIBPORTAL_FOUND true)
+      add_definitions(-DWINAPI_LIBPORTAL=1)
+      include_directories(${libportal_src_dir}/libportal)
+    else()
+      message(WARNING "Local libportal not found")
+    endif()
   endif()
 
   pkg_check_modules(LIBXKBCOMMON REQUIRED xkbcommon)

--- a/config.yaml
+++ b/config.yaml
@@ -185,7 +185,8 @@ config:
           libgtk-3-dev \
           libprotobuf-c-dev \
           libsystemd-dev \
-          libgirepository1.0-dev
+          libgirepository1.0-dev \
+          qt6-base-private-dev
 
         ubuntu: *debian_libportal
         linuxmint: *debian_libportal

--- a/meson.build
+++ b/meson.build
@@ -36,6 +36,6 @@ if host_machine.system() == 'linux'
     dependency('libportal', required: false)
   else
     # Using the subproject is only useful for development; it's not intended for normal use.
-    subproject('libportal', default_options: ['docs=false', 'backend-gtk3=enabled'])
+    subproject('libportal', default_options: ['docs=false', 'backend-gtk3=enabled', 'backend-qt6=disabled'])
   endif
 endif

--- a/scripts/install_deps.py
+++ b/scripts/install_deps.py
@@ -16,7 +16,7 @@ def main():
     if is_ci:
         print("CI environment detected")
 
-    args = parseArgs(is_ci)
+    args = parse_args(is_ci)
 
     env.ensure_dependencies()
     env.ensure_in_venv(__file__, auto_create=True)
@@ -62,7 +62,7 @@ def main():
         sys.exit(1)
 
 
-def parseArgs(is_ci):
+def parse_args(is_ci):
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--pause-on-exit", action="store_true", help="Useful on Windows"

--- a/scripts/install_deps.py
+++ b/scripts/install_deps.py
@@ -93,7 +93,7 @@ def parseArgs(is_ci):
         help="Install built Meson subprojects to system",
     )
     parser.add_argument(
-        "--meson-skip-system",
+        "--meson-no-system",
         nargs="+",
         help="Specify which Meson subprojects to use instead of system dependencies",
     )
@@ -111,22 +111,22 @@ def run(args):
         deps.install()
 
     if not args.skip_meson:
-        run_meson(args.meson_install, args.meson_skip_system)
+        run_meson(args.meson_install, args.meson_no_system)
 
 
 # It's a bit weird to use Meson just for installing deps, but it's a stopgap until
 # we fully switch from CMake to Meson. For the meantime, Meson will install the deps
 # so that CMake can find them easily. Once we switch to Meson, it might be possible for
 # Meson handle the deps resolution, so that we won't need to install them on the system.
-def run_meson(meson_install, meson_skip_system):
-    meson.setup(meson_skip_system)
+def run_meson(install, no_system_list):
+    meson.setup(no_system_list)
 
     # Only compile and install on Linux for now, since we're only using Meson to fetch
     # the deps on Windows and macOS.
     if env.is_linux():
         meson.compile()
 
-    if meson_install:
+    if install:
         meson.install()
 
 

--- a/scripts/lib/meson.py
+++ b/scripts/lib/meson.py
@@ -15,8 +15,12 @@ def setup(no_system_list):
     for subproject in no_system_list:
         cmd.append(f"-Dsystem_{subproject}=false")
 
+    # This might be a bit rude, but Meson seems to cache a lot (like CMake),
+    # so wiping every time is the easiest way to ensure that the build is clean.
+    # Plus, the way we're using Meson (at the moment) is just for satisfying
+    # dependencies, so this script is run infrequently enough to not matter.
     if os.path.exists(build_dir):
-        cmd.append("--reconfigure")
+        cmd.append("--wipe")
 
     cmd_utils.run(cmd, print_cmd=True)
 

--- a/scripts/lib/meson.py
+++ b/scripts/lib/meson.py
@@ -6,13 +6,13 @@ build_dir = "build/meson"
 meson_bin = env.get_python_executable("meson")
 
 
-def setup(meson_skip_system):
+def setup(no_system_list):
     cmd = [meson_bin, "setup", build_dir]
 
     if env.is_windows():
         cmd.append("-Dsystem_gtest=false")
 
-    for subproject in meson_skip_system:
+    for subproject in no_system_list:
         cmd.append(f"-Dsystem_{subproject}=false")
 
     if os.path.exists(build_dir):

--- a/scripts/lib/meson.py
+++ b/scripts/lib/meson.py
@@ -6,11 +6,14 @@ build_dir = "build/meson"
 meson_bin = env.get_python_executable("meson")
 
 
-def setup():
+def setup(meson_skip_system):
     cmd = [meson_bin, "setup", build_dir]
 
     if env.is_windows():
         cmd.append("-Dsystem_gtest=false")
+
+    for subproject in meson_skip_system:
+        cmd.append(f"-Dsystem_{subproject}=false")
 
     if os.path.exists(build_dir):
         cmd.append("--reconfigure")

--- a/subprojects/libei.wrap
+++ b/subprojects/libei.wrap
@@ -1,3 +1,3 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/libinput/libei.git
-revision = tags/1.3.0
+revision = main

--- a/subprojects/libportal.wrap
+++ b/subprojects/libportal.wrap
@@ -1,3 +1,3 @@
 [wrap-git]
 url = https://github.com/flatpak/libportal.git
-revision = a1530a9
+revision = main


### PR DESCRIPTION
> Installing the built libportal causes issues such as Nautilus not working (maybe a libportal bug report is needed).

> Instead of installing, use the local build if SYSTEM_LIBPORTAL is false. Also, use master instead of tag (for all git subprojects), since it’s only used for development. An arg for install_deps.py such as --no-system libportal,libei would be useful.

# To test:

1. Use GNOME46 (sorry, haven't tested with KDE yet but I plan to)
1. Install the deps for `libportal`:
    - Debian-like: `./scripts/install_deps.py --subproject libportal`
    - Other distro: Sorry, no script but you can probably work out the deps from [`config.yaml`](https://github.com/symless/synergy/blob/df6fdb3eda5f35624d33e9109206d46a4cfd1e30/config.yaml#L175)
1. Build local `libportal`:
    - Run: `./scripts/install_deps.py --meson-no-system libportal`
    - Or, run Meson direct: `meson setup build/meson -Dsystem_libportal=false`
3. Configure with system `libportal` disabled: `cmake -B build -DSYSTEM_LIBPORTAL=OFF`
4. Build the project: `cmake --build build -j8`
5. Verify that `synergys` is linked against the local `libportal.so` that you just built:
    ```
    $ ldd build/bin/synergys | grep libportal
    libportal.so.1 => /path/to/synergy/build/meson/subprojects/libportal/libportal/libportal.so.1 (0x00007f8aa1160000)
    ```
    ... and not the system `libportal` (e.g. `/usr/lib`, `/usr/local/lib`, etc)
6. Run using the GUI: `build/bin/synergy`
7. Verify that you see: `INFO: using ei screen for wayland` in the logs

---
https://symless.atlassian.net/browse/S1-1826