### PR TITLE
Port EI fixes to use `pipe2` instead of `pipe` and `fcntl`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -58,7 +58,7 @@
       "cwd": "${workspaceRoot}",
       "request": "launch",
       "program": "${workspaceFolder}/build/bin/synergys",
-      "preLaunchTask": "build"
+      "preLaunchTask": "kill-build"
     },
     {
       "name": "server windows",
@@ -67,7 +67,7 @@
       "request": "launch",
       "program": "${workspaceFolder}/build/bin/synergys",
       "internalConsoleOptions": "openOnSessionStart",
-      "preLaunchTask": "build"
+      "preLaunchTask": "kill-build"
     },
     {
       "name": "client unix",
@@ -75,7 +75,7 @@
       "cwd": "${workspaceRoot}",
       "request": "launch",
       "program": "${workspaceFolder}/build/bin/synergyc",
-      "preLaunchTask": "build"
+      "preLaunchTask": "kill-build"
     },
     {
       "name": "client windows",
@@ -84,7 +84,7 @@
       "request": "launch",
       "program": "${workspaceFolder}/build/bin/synergyc",
       "internalConsoleOptions": "openOnSessionStart",
-      "preLaunchTask": "build"
+      "preLaunchTask": "kill-build"
     },
     {
       "name": "daemon windows",

--- a/src/lib/platform/EiEventQueueBuffer.cpp
+++ b/src/lib/platform/EiEventQueueBuffer.cpp
@@ -40,14 +40,8 @@ EiEventQueueBuffer::EiEventQueueBuffer(
       events_(events) {
   // We need a pipe to signal ourselves when addEvent() is called
   int pipefd[2];
-  int result = pipe(pipefd);
+  int result = pipe2(pipefd, O_NONBLOCK);
   assert(result == 0);
-
-  int pipeflags;
-  pipeflags = fcntl(pipefd[0], F_GETFL);
-  fcntl(pipefd[0], F_SETFL, pipeflags | O_NONBLOCK);
-  pipeflags = fcntl(pipefd[1], F_GETFL);
-  fcntl(pipefd[1], F_SETFL, pipeflags | O_NONBLOCK);
 
   pipe_r_ = pipefd[0];
   pipe_w_ = pipefd[1];

--- a/src/lib/platform/XWindowsEventQueueBuffer.cpp
+++ b/src/lib/platform/XWindowsEventQueueBuffer.cpp
@@ -51,14 +51,8 @@ XWindowsEventQueueBuffer::XWindowsEventQueueBuffer(
 
   m_userEvent = XInternAtom(m_display, "SYNERGY_USER_EVENT", False);
   // set up for pipe hack
-  int result = pipe(m_pipefd);
+  int result = pipe2(m_pipefd, O_NONBLOCK);
   assert(result == 0);
-
-  int pipeflags;
-  pipeflags = fcntl(m_pipefd[0], F_GETFL);
-  fcntl(m_pipefd[0], F_SETFL, pipeflags | O_NONBLOCK);
-  pipeflags = fcntl(m_pipefd[1], F_GETFL);
-  fcntl(m_pipefd[1], F_SETFL, pipeflags | O_NONBLOCK);
 }
 
 XWindowsEventQueueBuffer::~XWindowsEventQueueBuffer() {


### PR DESCRIPTION
> just noticed that doing a pipe2(pipefd, O_NONBLOCK) might be smarter here

@whot Looks good, tested on Wayland and X, client and server with libei main and libportal main :+1: 

---

https://symless.atlassian.net/browse/S1-1812

