### PR TITLE
Use `vcpkg` to manage `openssl` dep instead of `choco`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,9 @@ jobs:
       - name: Install dependencies
         run: python ./scripts/install_deps.py
 
+      - name: Cleanup vcpkg downloads
+        run: rmdir /s /q vcpkg/downloads
+
       - name: Setup VC++ environment
         uses: ilammy/msvc-dev-cmd@v1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         run: python ./scripts/install_deps.py
 
       - name: Cleanup vcpkg downloads
-        run: rmdir /s /q vcpkg/downloads
+        run: Remove-Item -Path vcpkg/downloads -Recurse -Force
 
       - name: Setup VC++ environment
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,6 @@ jobs:
           path: ./deps
           key: ${{ runner.os }}-deps-${{ hashFiles('config.yaml') }}
 
-      - name: Install winget
-        uses: Cyberboss/install-winget@v1
-
       - name: Install dependencies
         run: python ./scripts/install_deps.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,12 +74,6 @@ jobs:
             vcpkg_installed
           key: vcpkg-${{ runner.os }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
 
-      - name: Cache Chocolatey packages
-        uses: actions/cache@v4
-        with:
-          path: ${{ runner.temp }}/choco
-          key: choco-${{ hashFiles('Chocolatey.config') }}
-
       - name: Cache deps dir
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,8 @@ jobs:
           path: ./deps
           key: ${{ runner.os }}-deps-${{ hashFiles('config.yaml') }}
 
-      # Install the VC++ environment with an action instead of using Chocolatey,
-      # as it's more reliable and faster.
+      # This effectively runs `vcvarsall.bat`, etc. It's not actually installing
+      # VC++ as that's already pre-installed on the Windows runner.
       - name: Setup VC++ environment
         uses: ilammy/msvc-dev-cmd@v1
 
@@ -94,6 +94,8 @@ jobs:
       - name: Install dependencies
         run: python ./scripts/install_deps.py
 
+      # The vcpkg downloads dir can be quite large (over 2GB) which bloats the cache.
+      # For the most part, we don't need it so it probably safe to discard it.
       - name: Cleanup vcpkg downloads
         run: Remove-Item -Path vcpkg/downloads -Recurse -Force
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
         with:
           submodules: "recursive"
 
+      # TOOD: cache vcpkg and vcpkg_installed
+
       - name: Cache Chocolatey packages
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,9 @@ jobs:
           path: ./deps
           key: ${{ runner.os }}-deps-${{ hashFiles('config.yaml') }}
 
+      - name: Install winget
+        uses: Cyberboss/install-winget@v1
+
       - name: Install dependencies
         run: python ./scripts/install_deps.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,10 @@ jobs:
           path: ./deps
           key: ${{ runner.os }}-deps-${{ hashFiles('config.yaml') }}
 
-      - name: Install dependencies
-        run: python ./scripts/install_deps.py
-
-      - name: Cleanup vcpkg downloads
-        run: Remove-Item -Path vcpkg/downloads -Recurse -Force
+      # Install the VC++ environment with an action instead of using Chocolatey,
+      # as it's more reliable and faster.
+      - name: Setup VC++ environment
+        uses: ilammy/msvc-dev-cmd@v1
 
       # Install Ninja with an action instead of using Chocolatey, as it's more
       # reliable and faster. The Ninja install action is pretty good as it
@@ -92,10 +91,11 @@ jobs:
       - name: Install Ninja
         uses: seanmiddleditch/gha-setup-ninja@master
 
-      # Install the VC++ environment with an action instead of using Chocolatey,
-      # as it's more reliable and faster.
-      - name: Setup VC++ environment
-        uses: ilammy/msvc-dev-cmd@v1
+      - name: Install dependencies
+        run: python ./scripts/install_deps.py
+
+      - name: Cleanup vcpkg downloads
+        run: Remove-Item -Path vcpkg/downloads -Recurse -Force
 
       - name: Configure
         run: cmake -B build --preset=windows-release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,12 @@ jobs:
       - name: Cleanup vcpkg downloads
         run: Remove-Item -Path vcpkg/downloads -Recurse -Force
 
+      # The Ninja install action is pretty good as it downloads directly from
+      # the `ninja-build` GitHub project releases. We use this instead of
+      # Chocolatey as it's more reliable and faster.
+      - name: Install Ninja
+        uses: seanmiddleditch/gha-setup-ninja@master
+
       - name: Setup VC++ environment
         uses: ilammy/msvc-dev-cmd@v1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,13 @@ jobs:
         with:
           submodules: "recursive"
 
-      # TOOD: cache vcpkg and vcpkg_installed
+      - name: Cache vcpkg dirs
+        uses: actions/cache@v4
+        with:
+          path: |
+            vcpkg
+            vcpkg_installed
+          key: vcpkg-${{ runner.os }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
 
       - name: Cache Chocolatey packages
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,12 +86,14 @@ jobs:
       - name: Cleanup vcpkg downloads
         run: Remove-Item -Path vcpkg/downloads -Recurse -Force
 
-      # The Ninja install action is pretty good as it downloads directly from
-      # the `ninja-build` GitHub project releases. We use this instead of
-      # Chocolatey as it's more reliable and faster.
+      # Install Ninja with an action instead of using Chocolatey, as it's more
+      # reliable and faster. The Ninja install action is pretty good as it
+      # downloads directly from the `ninja-build` GitHub project releases.
       - name: Install Ninja
         uses: seanmiddleditch/gha-setup-ninja@master
 
+      # Install the VC++ environment with an action instead of using Chocolatey,
+      # as it's more reliable and faster.
       - name: Setup VC++ environment
         uses: ilammy/msvc-dev-cmd@v1
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /dist
 /deps
 /tmp
+/vcpkg*
 /scripts/**/*.pyc
 aqtinstall.log
 Brewfile.lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@
 /dist
 /deps
 /tmp
-/vcpkg*
+/vcpkg
+/vcpkg_installed
 /scripts/**/*.pyc
 aqtinstall.log
 Brewfile.lock.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -107,6 +107,13 @@
       "type": "lldb",
       "request": "attach",
       "pid": "${command:pickProcess}"
+    },
+    {
+      "name": "install_deps.py",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "scripts/install_deps.py",
+      "console": "integratedTerminal"
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "gui unix",
+      "name": "unix - gui",
       "type": "lldb",
       "cwd": "${workspaceRoot}",
       "request": "launch",
@@ -10,7 +10,45 @@
       "preLaunchTask": "kill-build"
     },
     {
-      "name": "gui windows",
+      "name": "unix - unittests",
+      "type": "lldb",
+      "cwd": "${workspaceRoot}",
+      "request": "launch",
+      "program": "${workspaceFolder}/build/bin/unittests",
+      "preLaunchTask": "build"
+    },
+    {
+      "name": "unix - integtests",
+      "type": "lldb",
+      "cwd": "${workspaceRoot}",
+      "request": "launch",
+      "program": "${workspaceFolder}/build/bin/integtests",
+      "preLaunchTask": "build"
+    },
+    {
+      "name": "unix - server",
+      "type": "lldb",
+      "cwd": "${workspaceRoot}",
+      "request": "launch",
+      "program": "${workspaceFolder}/build/bin/synergys",
+      "preLaunchTask": "kill-build"
+    },
+    {
+      "name": "unix - client",
+      "type": "lldb",
+      "cwd": "${workspaceRoot}",
+      "request": "launch",
+      "program": "${workspaceFolder}/build/bin/synergyc",
+      "preLaunchTask": "kill-build"
+    },
+    {
+      "name": "unix - attach",
+      "type": "lldb",
+      "request": "attach",
+      "pid": "${command:pickProcess}"
+    },
+    {
+      "name": "windows - gui",
       "type": "cppvsdbg",
       "cwd": "${workspaceRoot}",
       "request": "launch",
@@ -19,15 +57,7 @@
       "preLaunchTask": "kill-build"
     },
     {
-      "name": "unittests unix",
-      "type": "lldb",
-      "cwd": "${workspaceRoot}",
-      "request": "launch",
-      "program": "${workspaceFolder}/build/bin/unittests",
-      "preLaunchTask": "build"
-    },
-    {
-      "name": "unittests windows",
+      "name": "windows - unittests",
       "type": "cppvsdbg",
       "cwd": "${workspaceRoot}",
       "request": "launch",
@@ -36,15 +66,7 @@
       "preLaunchTask": "build"
     },
     {
-      "name": "integtests unix",
-      "type": "lldb",
-      "cwd": "${workspaceRoot}",
-      "request": "launch",
-      "program": "${workspaceFolder}/build/bin/integtests",
-      "preLaunchTask": "build"
-    },
-    {
-      "name": "integtests windows",
+      "name": "windows - integtests",
       "type": "cppvsdbg",
       "cwd": "${workspaceRoot}",
       "request": "launch",
@@ -53,15 +75,7 @@
       "preLaunchTask": "build"
     },
     {
-      "name": "server unix",
-      "type": "lldb",
-      "cwd": "${workspaceRoot}",
-      "request": "launch",
-      "program": "${workspaceFolder}/build/bin/synergys",
-      "preLaunchTask": "kill-build"
-    },
-    {
-      "name": "server windows",
+      "name": "windows - server",
       "type": "cppvsdbg",
       "cwd": "${workspaceRoot}",
       "request": "launch",
@@ -70,15 +84,7 @@
       "preLaunchTask": "kill-build"
     },
     {
-      "name": "client unix",
-      "type": "lldb",
-      "cwd": "${workspaceRoot}",
-      "request": "launch",
-      "program": "${workspaceFolder}/build/bin/synergyc",
-      "preLaunchTask": "kill-build"
-    },
-    {
-      "name": "client windows",
+      "name": "windows - client",
       "type": "cppvsdbg",
       "cwd": "${workspaceRoot}",
       "request": "launch",
@@ -87,7 +93,7 @@
       "preLaunchTask": "kill-build"
     },
     {
-      "name": "daemon windows",
+      "name": "windows - daemon",
       "type": "cppvsdbg",
       "cwd": "${workspaceRoot}",
       "request": "launch",
@@ -97,16 +103,10 @@
       "preLaunchTask": "build"
     },
     {
-      "name": "windows attach",
+      "name": "windows - attach",
       "type": "cppvsdbg",
       "request": "attach",
       "processId": "${command:pickProcess}"
-    },
-    {
-      "name": "unix attach",
-      "type": "lldb",
-      "request": "attach",
-      "pid": "${command:pickProcess}"
     },
     {
       "name": "install_deps.py",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Synergy -- mouse and keyboard sharing utility
-# Copyright (C) 2012-2024 Symless Ltd.
-# Copyright (C) 2009-2012 Nick Bolton
+# Copyright (C) 2024 Symless Ltd.
+# Copyright (C) 2009 Nick Bolton
 #
 # This package is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -25,9 +25,6 @@
         "CMAKE_C_COMPILER": "cl.exe",
         "CMAKE_CXX_COMPILER": "cl.exe"
       },
-      "environment": {
-        "SYNERGY_STATIC_OPENSSL": "ON"
-      },
       "architecture": {
         "value": "x64",
         "strategy": "external"

--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,7 @@ Enhancements:
 - #7465 Also cut `+` char for `SHORT_VERSION` var used on upload
 - #7467 Load server or client args from `synergy-config.toml`
 - #7469 Option to link against local `libportal` and other subprojects
+- #7471 Use `vcpkg` to manage `openssl` dep instead of `choco`
 
 # 1.15.1
 

--- a/Chocolatey.config
+++ b/Chocolatey.config
@@ -4,7 +4,6 @@
 <packages>
   <package id="cmake" />
   <package id="ninja" />
-  <package id="openssl" />
   <package id="wixtoolset" />
   <package id="visualstudio2022buildtools"
     packageParameters="--includeRecommended --add Microsoft.VisualStudio.Workload.MSBuildTools --add Microsoft.VisualStudio.Workload.VCTools " />

--- a/Chocolatey.config
+++ b/Chocolatey.config
@@ -2,8 +2,6 @@
 
 <!-- install with: choco install Chocolatey.config -y -->
 <packages>
-  <package id="cmake" />
-  <package id="ninja" />
   <package id="wixtoolset" />
   <package id="visualstudio2022buildtools"
     packageParameters="--includeRecommended --add Microsoft.VisualStudio.Workload.MSBuildTools --add Microsoft.VisualStudio.Workload.VCTools " />

--- a/Chocolatey.config
+++ b/Chocolatey.config
@@ -4,6 +4,7 @@
 <packages>
   <package id="cmake" />
   <package id="ninja" />
+  <package id="openssl" />
   <package id="wixtoolset" />
   <package id="visualstudio2022buildtools"
     packageParameters="--includeRecommended --add Microsoft.VisualStudio.Workload.MSBuildTools --add Microsoft.VisualStudio.Workload.VCTools " />

--- a/Chocolatey.config
+++ b/Chocolatey.config
@@ -2,6 +2,8 @@
 
 <!-- install with: choco install Chocolatey.config -y -->
 <packages>
+  <package id="cmake" />
+  <package id="ninja" />
   <package id="wixtoolset" />
   <package id="visualstudio2022buildtools"
     packageParameters="--includeRecommended --add Microsoft.VisualStudio.Workload.MSBuildTools --add Microsoft.VisualStudio.Workload.VCTools " />

--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -433,9 +433,31 @@ macro(configure_windows_libs)
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/res/win/version.rc.in
                  ${CMAKE_BINARY_DIR}/src/version.rc @ONLY)
 
-  find_openssl_dir_win32(OPENSSL_PATH)
-  add_definitions(-DOPENSSL_PATH="${OPENSSL_PATH}")
+  configure_windows_openssl()
 
+endmacro()
+
+macro(configure_windows_openssl)
+  # Strangely, vcpkg doesn't seem to put openssl.exe in the `vcpkg_installed` dir,
+  # so we have to fish it out of the `vcpkg/buildtrees` dir.
+  set(OPENSSL_EXE_DIR
+      ${CMAKE_SOURCE_DIR}/vcpkg/buildtrees/openssl/x64-windows-rel/apps)
+  set(OPENSSL_ROOT_DIR ${CMAKE_SOURCE_DIR}/vcpkg_installed/x64-windows)
+
+  if(EXISTS ${OPENSSL_EXE_DIR})
+    message(STATUS "OpenSSL exe dir: ${OPENSSL_EXE_DIR}")
+    add_definitions(-DOPENSSL_EXE_DIR="${OPENSSL_EXE_DIR}")
+  else()
+    message(FATAL_ERROR "OpenSSL exe dir not found: ${OPENSSL_EXE_DIR}")
+  endif()
+
+  if(EXISTS ${OPENSSL_ROOT_DIR})
+    message(STATUS "OpenSSL root dir: ${OPENSSL_ROOT_DIR}")
+  else()
+    message(FATAL_ERROR "OpenSSL root dir not found: ${OPENSSL_ROOT_DIR}")
+  endif()
+
+  include_directories(${OPENSSL_ROOT_DIR}/include)
 endmacro()
 
 macro(configure_qt)
@@ -453,7 +475,8 @@ macro(configure_openssl)
   # Apple has to use static libraries because "Use of the Apple-provided OpenSSL
   # libraries by apps is strongly discouraged."
   # https://developer.apple.com/library/archive/documentation/Security/Conceptual/cryptoservices/SecureNetworkCommunicationAPIs/SecureNetworkCommunicationAPIs.html
-  if(APPLE OR DEFINED ENV{SYNERGY_STATIC_OPENSSL})
+  # TODO: How about bundling the OpenSSL .dylib files with the app so they can be updated?
+  if(APPLE)
     set(OPENSSL_USE_STATIC_LIBS TRUE)
   endif()
 
@@ -560,39 +583,6 @@ macro(configure_python)
     set(PYTHON_BIN "${CMAKE_BINARY_DIR}/python/bin/python")
   endif()
 endmacro()
-
-#
-# Find the OpenSSL directory on Windows based on the location of the first
-# `openssl` binary found.
-#
-function(find_openssl_dir_win32 result)
-
-  execute_process(
-    COMMAND where openssl
-    OUTPUT_VARIABLE OPENSSL_PATH
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-  # It's possible that there are multiple OpenSSL installations on the system,
-  # which is the case on GitHub runners. For now we'll pick the first one, but
-  # that's probably not very robust. Maybe our choco config could install to a
-  # specific location?
-  string(REGEX REPLACE "\r?\n" ";" OPENSSL_PATH_LIST ${OPENSSL_PATH})
-  message(STATUS "Found OpenSSL binaries at: ${OPENSSL_PATH_LIST}")
-
-  list(GET OPENSSL_PATH_LIST 0 OPENSSL_FIRST_PATH)
-  message(VERBOSE "First OpenSSL binary: ${OPENSSL_FIRST_PATH}")
-
-  get_filename_component(OPENSSL_BIN_DIR ${OPENSSL_FIRST_PATH} DIRECTORY)
-  message(VERBOSE "OpenSSL bin dir: ${OPENSSL_BIN_DIR}")
-
-  get_filename_component(OPENSSL_DIR ${OPENSSL_BIN_DIR} DIRECTORY)
-  message(VERBOSE "OpenSSL install root dir: ${OPENSSL_DIR}")
-
-  set(${result}
-      ${OPENSSL_DIR}
-      PARENT_SCOPE)
-
-endfunction()
 
 macro(configure_wintoast)
   # WinToast is a pretty niche library, and there doesn't seem to be an installable package,

--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -456,8 +456,6 @@ macro(configure_windows_openssl)
   else()
     message(FATAL_ERROR "OpenSSL root dir not found: ${OPENSSL_ROOT_DIR}")
   endif()
-
-  include_directories(${OPENSSL_ROOT_DIR}/include)
 endmacro()
 
 macro(configure_qt)
@@ -481,6 +479,7 @@ macro(configure_openssl)
   endif()
 
   find_package(OpenSSL REQUIRED)
+  include_directories(${OPENSSL_INCLUDE_DIR})
 endmacro()
 
 macro(configure_gtest)

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,10 @@
 config:
   windows:
     dependencies:
-      command: choco install Chocolatey.config -y
+      command: |
+        winget install Microsoft.Vcpkg chocolatey && \
+        vcpkg.exe install openssl && \
+        choco install Chocolatey.config -y --no-progress
       qt:
         version: 6.7
         mirror: https://qt.mirror.constant.com/

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,14 @@
 config:
   windows:
     dependencies:
-      command: choco install Chocolatey.config -y
+      command: |
+        winget install \
+          --silent --accept-package-agreements --accept-source-agreements \
+          Kitware.CMake \
+          Ninja-build.Ninja \
+          chocolatey \
+        && \
+        choco install Chocolatey.config -y
       qt:
         version: 6.7
         mirror: https://qt.mirror.constant.com/
@@ -9,7 +16,6 @@ config:
       ci:
         edit-config: Chocolatey.config
         skip-packages:
-          - cmake
           - wixtoolset
           - visualstudio2022buildtools
 

--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,8 @@ config:
       command-elevated: |
         if not defined CI (choco install Chocolatey.config -y)
       command: |
-        winget install ninja-build.ninja cmake
+        if defined CI (scoop install ninja cmake)
+        else (winget install ninja-build.ninja cmake)
       qt:
         version: 6.7
         mirror: https://qt.mirror.constant.com/

--- a/config.yaml
+++ b/config.yaml
@@ -1,17 +1,18 @@
 config:
   windows:
     dependencies:
-      command: choco install Chocolatey.config -y
+      # We only run choco in dev env and not in CI, as it's pretty unreliable and slow.
+      # The Chocolatey mirror cannot be 100% reliable (according to docs) so it will
+      # often fail with an error `503 (Service Unavailable: Back-end server is at capacity)`
+      # which causes the nightly CI to fail intermittently.
+      command-elevated: |
+        if not defined CI (choco install Chocolatey.config -y)
+      command: |
+        winget install ninja-build.ninja cmake
       qt:
         version: 6.7
         mirror: https://qt.mirror.constant.com/
         base-dir: ./deps/qt
-      ci:
-        edit-config: Chocolatey.config
-        skip-packages:
-          - cmake
-          - wixtoolset
-          - visualstudio2022buildtools
 
   mac:
     dependencies:

--- a/config.yaml
+++ b/config.yaml
@@ -31,6 +31,10 @@ config:
           ninja-build \
           g++ \
           file \
+          curl \
+          zip \
+          unzip \
+          tar \
           xorg-dev \
           libx11-dev \
           libxtst-dev \
@@ -65,6 +69,10 @@ config:
           ninja-build \
           gcc-c++ \
           rpm-build \
+          curl \
+          zip \
+          unzip \
+          tar \
           openssl-devel \
           glib2-devel \
           gdk-pixbuf2-devel \
@@ -111,6 +119,10 @@ config:
           ninja \
           gcc-c++ \
           rpm-build \
+          curl \
+          zip \
+          unzip \
+          tar \
           libopenssl-devel \
           glib2-devel \
           gdk-pixbuf-devel \
@@ -133,6 +145,10 @@ config:
           cmake \
           ninja \
           gcc \
+          curl \
+          zip \
+          unzip \
+          tar \
           openssl \
           glib2 \
           gdk-pixbuf2 \

--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,7 @@ config:
         edit-config: Chocolatey.config
         skip-packages:
           - cmake
+          - wixtoolset
           - visualstudio2022buildtools
 
   mac:

--- a/config.yaml
+++ b/config.yaml
@@ -1,15 +1,15 @@
 config:
   windows:
     dependencies:
-      # We only run choco in dev env and not in CI, as it's pretty unreliable and slow.
+      # We only run Choco in dev env and not in CI, as it's pretty unreliable and slow.
       # The Chocolatey mirror cannot be 100% reliable (according to docs) so it will
       # often fail with an error `503 (Service Unavailable: Back-end server is at capacity)`
       # which causes the nightly CI to fail intermittently.
-      command-elevated: |
-        if not defined CI (choco install Chocolatey.config -y)
-      command: |
-        if defined CI (scoop install ninja cmake)
-        else (winget install ninja-build.ninja cmake)
+      command-elevated: if not defined CI (choco install Chocolatey.config -y)
+
+      # We only run WinGet in dev env since it's not available in CI (GitHub Windows runner).
+      # It's simpler to solve the dependencies via the GitHub workflow.
+      command: if not defined CI (winget install ninja-build.ninja cmake)
       qt:
         version: 6.7
         mirror: https://qt.mirror.constant.com/

--- a/config.yaml
+++ b/config.yaml
@@ -1,14 +1,7 @@
 config:
   windows:
     dependencies:
-      command: |
-        winget install \
-          --silent --accept-package-agreements --accept-source-agreements \
-          Kitware.CMake \
-          Ninja-build.Ninja \
-          chocolatey \
-        && \
-        choco install Chocolatey.config -y
+      command: choco install Chocolatey.config -y
       qt:
         version: 6.7
         mirror: https://qt.mirror.constant.com/
@@ -16,6 +9,7 @@ config:
       ci:
         edit-config: Chocolatey.config
         skip-packages:
+          - cmake
           - wixtoolset
           - visualstudio2022buildtools
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,14 +1,15 @@
 config:
   windows:
     dependencies:
-      # We only run Choco in dev env and not in CI, as it's pretty unreliable and slow.
-      # The Chocolatey mirror cannot be 100% reliable (according to docs) so it will
-      # often fail with an error `503 (Service Unavailable: Back-end server is at capacity)`
-      # which causes the nightly CI to fail intermittently.
+      # We only run `choco` when not in CI env because it's pretty unreliable and slow.
+      # The Chocolatey mirror cannot be 100% reliable (according to docs) so it will often fail
+      # with an error `503 (Service Unavailable: Back-end server is at capacity)` which causes
+      # the nightly CI to fail intermittently.
       command-elevated: if not defined CI (choco install Chocolatey.config -y)
 
-      # We only run WinGet in dev env since it's not available in CI (GitHub Windows runner).
-      # It's simpler to solve the dependencies via the GitHub workflow.
+      # We only run `winget` when not in CI env; it's not available on the GitHub Windows runner.
+      # It's simpler to solve dependencies like Ninja with a GitHub workflow action, and cmake is
+      # already installed on the Windows runner.
       command: if not defined CI (winget install ninja-build.ninja cmake)
       qt:
         version: 6.7

--- a/config.yaml
+++ b/config.yaml
@@ -31,10 +31,6 @@ config:
           ninja-build \
           g++ \
           file \
-          curl \
-          zip \
-          unzip \
-          tar \
           xorg-dev \
           libx11-dev \
           libxtst-dev \
@@ -69,10 +65,6 @@ config:
           ninja-build \
           gcc-c++ \
           rpm-build \
-          curl \
-          zip \
-          unzip \
-          tar \
           openssl-devel \
           glib2-devel \
           gdk-pixbuf2-devel \
@@ -119,10 +111,6 @@ config:
           ninja \
           gcc-c++ \
           rpm-build \
-          curl \
-          zip \
-          unzip \
-          tar \
           libopenssl-devel \
           glib2-devel \
           gdk-pixbuf-devel \
@@ -145,10 +133,6 @@ config:
           cmake \
           ninja \
           gcc \
-          curl \
-          zip \
-          unzip \
-          tar \
           openssl \
           glib2 \
           gdk-pixbuf2 \

--- a/config.yaml
+++ b/config.yaml
@@ -1,10 +1,7 @@
 config:
   windows:
     dependencies:
-      command: |
-        winget install Microsoft.Vcpkg chocolatey && \
-        vcpkg.exe install openssl && \
-        choco install Chocolatey.config -y --no-progress
+      command: choco install Chocolatey.config -y
       qt:
         version: 6.7
         mirror: https://qt.mirror.constant.com/

--- a/cspell.json
+++ b/cspell.json
@@ -7,6 +7,7 @@
     "aqtinstall",
     "Axelson",
     "Breen",
+    "buildtools",
     "codesign",
     "codesigning",
     "Compat",
@@ -27,6 +28,7 @@
     "integtests",
     "keychain",
     "Keychains",
+    "Kitware",
     "Kutytska",
     "Lanz",
     "libei",
@@ -61,7 +63,8 @@
     "Valgrind",
     "vcpkg",
     "Volker",
-    "winget"
+    "winget",
+    "wixtoolset"
   ],
   "ignoreWords": [],
   "import": []

--- a/cspell.json
+++ b/cspell.json
@@ -59,6 +59,7 @@
     "synergyd",
     "synergys",
     "Valgrind",
+    "vcpkg",
     "Volker",
     "winget"
   ],

--- a/cspell.json
+++ b/cspell.json
@@ -7,7 +7,6 @@
     "aqtinstall",
     "Axelson",
     "Breen",
-    "buildtools",
     "codesign",
     "codesigning",
     "Compat",
@@ -28,7 +27,6 @@
     "integtests",
     "keychain",
     "Keychains",
-    "Kitware",
     "Kutytska",
     "Lanz",
     "libei",
@@ -63,8 +61,7 @@
     "Valgrind",
     "vcpkg",
     "Volker",
-    "winget",
-    "wixtoolset"
+    "winget"
   ],
   "ignoreWords": [],
   "import": []

--- a/res/dist/wix/Include.wxi.in
+++ b/res/dist/wix/Include.wxi.in
@@ -18,6 +18,6 @@
     <?define QtPath="@QT_PATH@"?>
     <?define QtBinPath="$(var.QtPath)\bin"?>
     <?define QtPluginsPath="$(var.QtPath)\plugins"?>
-    <?define OpenSSLPath="@OPENSSL_PATH@"?>
-    <?define OpenSSLBinPath="$(var.OpenSSLPath)\bin"?>
+    <?define OpenSslExeDir="@OPENSSL_EXE_DIR@"?>
+    <?define OpenSslDllDir="@OPENSSL_ROOT_DIR@/bin"?>
 </Include>

--- a/res/dist/wix/Product.wxs
+++ b/res/dist/wix/Product.wxs
@@ -90,11 +90,11 @@
 				</File>
 				<File Source="$(var.BinPath)/syntool.exe"/>
 				<?if $(var.Platform) = x64 ?>
-					<File Source="$(var.OpenSSLBinPath)/libssl-3-x64.dll"/>
-					<File Source="$(var.OpenSSLBinPath)/libcrypto-3-x64.dll"/>
+					<File Source="$(var.OpenSslDllDir)/libssl-3-x64.dll"/>
+					<File Source="$(var.OpenSslDllDir)/libcrypto-3-x64.dll"/>
 				<?else ?>
-					<File Source="$(var.OpenSSLBinPath)/libssl-3.dll"/>
-					<File Source="$(var.OpenSSLBinPath)/libcrypto-3.dll"/>
+					<File Source="$(var.OpenSslDllDir)/libssl-3.dll"/>
+					<File Source="$(var.OpenSslDllDir)/libcrypto-3.dll"/>
 				<?endif ?>
 			</Component>
 			<Component Guid="BAC8149B-6287-45BF-9C27-43D71ED40214" Id="Gui">
@@ -140,13 +140,13 @@
 		<ComponentGroup Directory="OpenSSLDir" Id="OpenSSLComponents">
 			<Component Guid="92648F77-65A6-4B16-AC59-A1F37BD341B1" Id="OpenSSL">
 				<?if $(var.Platform) = x64 ?>
-					<File Id="OpenSSLDll1" Source="$(var.OpenSSLBinPath)/libcrypto-3-x64.dll"/>
-					<File Id="OpenSSLDll2" Source="$(var.OpenSSLBinPath)/libssl-3-x64.dll"/>
+					<File Id="OpenSSLDll1" Source="$(var.OpenSslDllDir)/libcrypto-3-x64.dll"/>
+					<File Id="OpenSSLDll2" Source="$(var.OpenSslDllDir)/libssl-3-x64.dll"/>
 				<?else ?>
-					<File Id="OpenSSLDll1" Source="$(var.OpenSSLBinPath)/libcrypto-3.dll"/>
-					<File Id="OpenSSLDll2" Source="$(var.OpenSSLBinPath)/libssl-3.dll"/>
+					<File Id="OpenSSLDll1" Source="$(var.OpenSslDllDir)/libcrypto-3.dll"/>
+					<File Id="OpenSSLDll2" Source="$(var.OpenSslDllDir)/libssl-3.dll"/>
 				<?endif ?>
-				<File Source="$(var.OpenSSLBinPath)/openssl.exe"/>
+				<File Source="$(var.OpenSslExeDir)/openssl.exe"/>
 				<File Source="$(var.ResPath)/openssl/synergy.conf"/>
 			</Component>
 		</ComponentGroup>

--- a/scripts/daemon.py
+++ b/scripts/daemon.py
@@ -1,5 +1,20 @@
 #!/usr/bin/env python3
 
+# Synergy -- mouse and keyboard sharing utility
+# Copyright (C) 2024 Symless Ltd.
+#
+# This package is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# found in the file LICENSE that should have accompanied this file.
+#
+# This package is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import lib.env as env
 
 env.ensure_in_venv(__file__)

--- a/scripts/daemon.py
+++ b/scripts/daemon.py
@@ -85,7 +85,7 @@ def print_verbose(context, message):
 
 def ensure_admin():
     if not windows.is_admin():
-        windows.relaunch_as_admin(__file__)
+        windows.run_elevated(__file__)
         sys.exit()
 
 

--- a/scripts/fancy_copy.py
+++ b/scripts/fancy_copy.py
@@ -1,5 +1,20 @@
 #!/usr/bin/env python3
 
+# Synergy -- mouse and keyboard sharing utility
+# Copyright (C) 2024 Symless Ltd.
+#
+# This package is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# found in the file LICENSE that should have accompanied this file.
+#
+# This package is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import lib.env as env
 
 env.ensure_in_venv(__file__)

--- a/scripts/install_deps.py
+++ b/scripts/install_deps.py
@@ -165,6 +165,8 @@ def install(args):
         return
 
     # Only install vcpkg dependencies on Windows, since on other OS it's not needed (yet).
+    # We probably won't ever need this on macOS and Linux since brew and apt/dnf/etc do a
+    # good job of providing dependencies. Where they don't, we can use Meson.
     if env.is_windows() and not args.skip_vcpkg:
         import lib.vcpkg as vcpkg
 

--- a/scripts/install_deps.py
+++ b/scripts/install_deps.py
@@ -37,20 +37,24 @@ def main():
 
     try:
         run(args)
+    except Exception:
+        traceback.print_exc()
+        sys.exit(1)
     finally:
-        if args.lock_file:
-            env.remove_lock_file(args.lock_file)
+        if env.is_windows() and args.pause_on_exit:
+            # Allow the rest of the install to continue while sitting at the pause.
+            if args.lock_file:
+                env.remove_lock_file(args.lock_file)
+
+            # Useful on Windows, when elevated, Python is opened in a new window and closes
+            # immediately after the script finishes. This keeps the script window open so that
+            # the user can see the output.
+            print()
+            input("Press enter to continue...")
 
 
 def parse_args(is_ci):
     parser = argparse.ArgumentParser()
-
-    if env.is_windows():
-        parser.add_argument(
-            "--pause-on-exit",
-            action="store_true",
-            help="Windows only: Useful to prevent elevated window from closing",
-        )
 
     parser.add_argument(
         "--ci-env",
@@ -67,11 +71,6 @@ def parse_args(is_ci):
         "--only-python", action="store_true", help="Only install Python dependencies"
     )
     parser.add_argument(
-        "--only-system",
-        action="store_true",
-        help="Only install system dependencies (apt, dnf, etc)",
-    )
-    parser.add_argument(
         "--skip-python",
         action="store_true",
         help="Do not install Python dependencies",
@@ -84,14 +83,6 @@ def parse_args(is_ci):
     parser.add_argument(
         "--skip-meson", action="store_true", help="Do not setup and compile with Meson"
     )
-
-    if env.is_windows():
-        parser.add_argument(
-            "--skip-vcpkg",
-            action="store_true",
-            help="Windows only: Do not install vcpkg dependencies",
-        )
-
     parser.add_argument(
         "--subproject", type=str, help="Sub-project to install dependencies for"
     )
@@ -105,6 +96,29 @@ def parse_args(is_ci):
         nargs="+",
         help="Specify which Meson subprojects to use instead of system dependencies",
     )
+
+    if env.is_windows():
+        parser.add_argument(
+            "--skip-vcpkg",
+            action="store_true",
+            help="Windows only: Do not install vcpkg dependencies",
+        )
+        parser.add_argument(
+            "--skip-elevated",
+            action="store_true",
+            help="Windows only: Do not run elevated command",
+        )
+        parser.add_argument(
+            "--only-elevated",
+            action="store_true",
+            help="Windows only: Only run elevated command",
+        )
+        parser.add_argument(
+            "--pause-on-exit",
+            action="store_true",
+            help="Windows only: Useful to prevent elevated window from closing",
+        )
+
     return parser.parse_args()
 
 
@@ -122,9 +136,10 @@ def run(args):
         print(colors.SUCCESS_TEXT + " Only Python dependencies installed")
         return
 
-    error = False
     try:
         install(args)
+
+        print()
         print(f"\n{colors.SUCCESS_TEXT} Dependencies installed")
 
         # On Windows and macOS, we set env vars for cmake, but for them to be picked up,
@@ -137,27 +152,15 @@ def run(args):
             )
     except Exception:
         traceback.print_exc()
-        error = True
-        print(f"\n{colors.ERROR_TEXT} Failed to install dependencies")
-
-    # Useful on Windows, when elevated, Python is opened in a new window and closes
-    # immediately after the script finishes. This keeps the script window open so that
-    # the user can see the output.
-    if env.is_windows() and args.pause_on_exit:
         print()
-        input("Press enter to continue...")
-
-    if error:
+        print(f"\n{colors.ERROR_TEXT} Failed to install dependencies")
         sys.exit(1)
 
 
 def install(args):
     if not args.skip_system:
-        deps = Dependencies(args.ci_env)
+        deps = Dependencies(args)
         deps.install()
-
-    if args.only_system:
-        return
 
     if args.subproject:
         deps = SubprojectDependencies(args.subproject)
@@ -194,11 +197,12 @@ def run_meson(install, no_system_list):
 
 class Dependencies:
 
-    def __init__(self, ci_env):
+    def __init__(self, args):
         from lib.config import Config
 
         self.config = Config()
-        self.ci_env = ci_env
+        self.args = args
+        self.ci_env = args.ci_env
 
     def install(self):
         """Installs dependencies for the current platform."""
@@ -216,11 +220,16 @@ class Dependencies:
         """Installs dependencies on Windows."""
         import lib.windows as windows
 
-        # Chocolatey requires admin privileges to install packages.
-        # If we move to winget, this will remove the need to elevate.
-        if not windows.is_admin():
-            windows.run_elevated(__file__, "--only-system --skip-python")
-            return
+        if not self.args.skip_elevated:
+            if not windows.is_admin():
+                windows.run_elevated(__file__, "--only-elevated --skip-python")
+            elif self.args.only_elevated:
+                # The choco command should run from the elevated command.
+                choco = windows.WindowsChoco()
+                choco.ensure_choco_installed()
+                command_elevated = self.config.get_os_deps_command("command-elevated")
+                cmd_utils.run(command_elevated, shell=True, print_cmd=True)
+                sys.exit(0)
 
         qt = qt_utils.WindowsQt(*self.config.get_qt_config())
         qt.install()
@@ -230,14 +239,9 @@ class Dependencies:
         else:
             windows.set_env_var(cmake_prefix_env_var, qt.get_install_dir())
 
-        choco = windows.WindowsChoco()
-        if self.ci_env:
-            choco.config_ci_cache()
-            edit_config, skip_packages = self.config.get_windows_ci_config()
-            choco.remove_from_config(edit_config, skip_packages)
-
         command = self.config.get_os_deps_command()
-        choco.install(command, self.ci_env)
+
+        cmd_utils.run(command, shell=True, print_cmd=True)
 
     def mac(self):
         """Installs dependencies on macOS."""

--- a/scripts/install_deps.py
+++ b/scripts/install_deps.py
@@ -44,9 +44,14 @@ def main():
 
 def parse_args(is_ci):
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--pause-on-exit", action="store_true", help="Useful on Windows"
-    )
+
+    if env.is_windows():
+        parser.add_argument(
+            "--pause-on-exit",
+            action="store_true",
+            help="Windows only: Useful to prevent elevated window from closing",
+        )
+
     parser.add_argument(
         "--ci-env",
         action="store_true",
@@ -79,9 +84,14 @@ def parse_args(is_ci):
     parser.add_argument(
         "--skip-meson", action="store_true", help="Do not setup and compile with Meson"
     )
-    parser.add_argument(
-        "--skip-vcpkg", action="store_true", help="Do not install vcpkg dependencies"
-    )
+
+    if env.is_windows():
+        parser.add_argument(
+            "--skip-vcpkg",
+            action="store_true",
+            help="Windows only: Do not install vcpkg dependencies",
+        )
+
     parser.add_argument(
         "--subproject", type=str, help="Sub-project to install dependencies for"
     )
@@ -133,7 +143,7 @@ def run(args):
     # Useful on Windows, when elevated, Python is opened in a new window and closes
     # immediately after the script finishes. This keeps the script window open so that
     # the user can see the output.
-    if args.pause_on_exit:
+    if env.is_windows() and args.pause_on_exit:
         print()
         input("Press enter to continue...")
 
@@ -154,7 +164,8 @@ def install(args):
         deps.install()
         return
 
-    if not args.skip_vcpkg:
+    # Only install vcpkg dependencies on Windows, since on other OS it's not needed (yet).
+    if env.is_windows() and not args.skip_vcpkg:
         import lib.vcpkg as vcpkg
 
         vcpkg.install()

--- a/scripts/install_deps.py
+++ b/scripts/install_deps.py
@@ -173,7 +173,11 @@ class Dependencies:
             choco.remove_from_config(edit_config, skip_packages)
 
         command = self.config.get_os_deps_command()
-        choco.install(command, self.ci_env)
+        cmd_utils.run(
+            command,
+            shell=True,
+            print_cmd=True,
+        )
 
     def mac(self):
         """Installs dependencies on macOS."""

--- a/scripts/install_deps.py
+++ b/scripts/install_deps.py
@@ -1,5 +1,20 @@
 #!/usr/bin/env python3
 
+# Synergy -- mouse and keyboard sharing utility
+# Copyright (C) 2024 Symless Ltd.
+#
+# This package is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# found in the file LICENSE that should have accompanied this file.
+#
+# This package is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import os, sys, argparse, traceback
 import lib.env as env
 import lib.cmd_utils as cmd_utils

--- a/scripts/install_deps.py
+++ b/scripts/install_deps.py
@@ -173,11 +173,7 @@ class Dependencies:
             choco.remove_from_config(edit_config, skip_packages)
 
         command = self.config.get_os_deps_command()
-        cmd_utils.run(
-            command,
-            shell=True,
-            print_cmd=True,
-        )
+        choco.install(command, self.ci_env)
 
     def mac(self):
         """Installs dependencies on macOS."""

--- a/scripts/lib/certificate.py
+++ b/scripts/lib/certificate.py
@@ -1,5 +1,20 @@
 import os, base64
 
+# Synergy -- mouse and keyboard sharing utility
+# Copyright (C) 2024 Symless Ltd.
+#
+# This package is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# found in the file LICENSE that should have accompanied this file.
+#
+# This package is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 temp_path = "tmp/certificate"
 
 

--- a/scripts/lib/cmd_utils.py
+++ b/scripts/lib/cmd_utils.py
@@ -1,3 +1,18 @@
+# Synergy -- mouse and keyboard sharing utility
+# Copyright (C) 2024 Symless Ltd.
+#
+# This package is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# found in the file LICENSE that should have accompanied this file.
+#
+# This package is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import subprocess
 import sys
 import lib.env as env

--- a/scripts/lib/colors.py
+++ b/scripts/lib/colors.py
@@ -1,3 +1,18 @@
+# Synergy -- mouse and keyboard sharing utility
+# Copyright (C) 2024 Symless Ltd.
+#
+# This package is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# found in the file LICENSE that should have accompanied this file.
+#
+# This package is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import colorama  # type: ignore
 from colorama import Fore  # type: ignore
 

--- a/scripts/lib/colors.py
+++ b/scripts/lib/colors.py
@@ -4,6 +4,6 @@ from colorama import Fore  # type: ignore
 colorama.init()
 
 SUCCESS_TEXT = f"{Fore.LIGHTGREEN_EX}Success:{Fore.RESET}"
-ERROR_TEXT = f"{Fore.RED}Error:{Fore.RESET}"
+ERROR_TEXT = f"{Fore.LIGHTRED_EX}Error:{Fore.RESET}"
 WARNING_TEXT = f"{Fore.LIGHTYELLOW_EX}Warning:{Fore.RESET}"
 HINT_TEXT = f"{Fore.LIGHTBLUE_EX}Hint:{Fore.RESET}"

--- a/scripts/lib/config.py
+++ b/scripts/lib/config.py
@@ -22,6 +22,7 @@ root_key = "config"
 deps_key = "dependencies"
 command_key = "command"
 command_pre_key = "command-pre"
+command_choco_key = "command-choco"
 subprojects_key = "subprojects"
 arrow = " ➤ "
 

--- a/scripts/lib/config.py
+++ b/scripts/lib/config.py
@@ -22,7 +22,6 @@ root_key = "config"
 deps_key = "dependencies"
 command_key = "command"
 command_pre_key = "command-pre"
-command_choco_key = "command-choco"
 subprojects_key = "subprojects"
 arrow = " ➤ "
 

--- a/scripts/lib/config.py
+++ b/scripts/lib/config.py
@@ -1,3 +1,18 @@
+# Synergy -- mouse and keyboard sharing utility
+# Copyright (C) 2024 Symless Ltd.
+#
+# This package is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# found in the file LICENSE that should have accompanied this file.
+#
+# This package is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import yaml
 import lib.env as env
 import lib.cmd_utils as cmd_utils

--- a/scripts/lib/env.py
+++ b/scripts/lib/env.py
@@ -1,3 +1,18 @@
+# Synergy -- mouse and keyboard sharing utility
+# Copyright (C) 2024 Symless Ltd.
+#
+# This package is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# found in the file LICENSE that should have accompanied this file.
+#
+# This package is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import os, sys, subprocess
 import lib.cmd_utils as cmd_utils
 

--- a/scripts/lib/env.py
+++ b/scripts/lib/env.py
@@ -248,3 +248,23 @@ def import_colors():
     import lib.colors as colors
 
     return colors
+
+
+def persist_lock_file(path):
+    """
+    Persists a lock file and ensures the directory part of the path exists.
+    """
+    dir_path = os.path.dirname(path)
+    if not os.path.exists(dir_path):
+        os.makedirs(dir_path, exist_ok=True)
+
+    with open(path, "w") as f:
+        f.write(str(os.getpid()))
+
+
+def remove_lock_file(path):
+    """
+    Removes a lock file if it exists.
+    """
+    if os.path.exists(path):
+        os.remove(path)

--- a/scripts/lib/file_utils.py
+++ b/scripts/lib/file_utils.py
@@ -1,3 +1,18 @@
+# Synergy -- mouse and keyboard sharing utility
+# Copyright (C) 2024 Symless Ltd.
+#
+# This package is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# found in the file LICENSE that should have accompanied this file.
+#
+# This package is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import glob, os, shutil, sys
 import lib.env as env
 import lib.colors as colors

--- a/scripts/lib/fs.py
+++ b/scripts/lib/fs.py
@@ -1,3 +1,18 @@
+# Synergy -- mouse and keyboard sharing utility
+# Copyright (C) 2024 Symless Ltd.
+#
+# This package is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# found in the file LICENSE that should have accompanied this file.
+#
+# This package is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import os, fnmatch
 
 

--- a/scripts/lib/github.py
+++ b/scripts/lib/github.py
@@ -1,3 +1,18 @@
+# Synergy -- mouse and keyboard sharing utility
+# Copyright (C) 2024 Symless Ltd.
+#
+# This package is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# found in the file LICENSE that should have accompanied this file.
+#
+# This package is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import os
 
 github_env_key = "GITHUB_ENV"

--- a/scripts/lib/linux.py
+++ b/scripts/lib/linux.py
@@ -1,3 +1,18 @@
+# Synergy -- mouse and keyboard sharing utility
+# Copyright (C) 2024 Symless Ltd.
+#
+# This package is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# found in the file LICENSE that should have accompanied this file.
+#
+# This package is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import os, shutil, glob, sys
 import lib.cmd_utils as cmd_utils
 import lib.env as env

--- a/scripts/lib/mac.py
+++ b/scripts/lib/mac.py
@@ -1,3 +1,18 @@
+# Synergy -- mouse and keyboard sharing utility
+# Copyright (C) 2024 Symless Ltd.
+#
+# This package is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# found in the file LICENSE that should have accompanied this file.
+#
+# This package is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import dmgbuild  # type: ignore
 import os, time, json, shutil
 import lib.cmd_utils as cmd_utils

--- a/scripts/lib/meson.py
+++ b/scripts/lib/meson.py
@@ -1,3 +1,18 @@
+# Synergy -- mouse and keyboard sharing utility
+# Copyright (C) 2024 Symless Ltd.
+#
+# This package is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# found in the file LICENSE that should have accompanied this file.
+#
+# This package is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import lib.cmd_utils as cmd_utils
 import lib.env as env
 import os

--- a/scripts/lib/qt_utils.py
+++ b/scripts/lib/qt_utils.py
@@ -1,3 +1,18 @@
+# Synergy -- mouse and keyboard sharing utility
+# Copyright (C) 2024 Symless Ltd.
+#
+# This package is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# found in the file LICENSE that should have accompanied this file.
+#
+# This package is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import os
 import lib.cmd_utils as cmd_utils
 import lib.env as env

--- a/scripts/lib/vcpkg.py
+++ b/scripts/lib/vcpkg.py
@@ -48,7 +48,7 @@ def ensure_vcpkg():
 
 def get_vcpkg():
     print("Downloading vcpkg...")
-    repo = git.Repo.clone_from(GIT_REPO, "vcpkg")
+    git.Repo.clone_from(GIT_REPO, "vcpkg")
 
     os.chdir("vcpkg")
     try:

--- a/scripts/lib/vcpkg.py
+++ b/scripts/lib/vcpkg.py
@@ -27,6 +27,8 @@ def install():
     cmd_utils.run([vcpkg_bin, "install"], print_cmd=True)
 
 
+# Install a local vcpkg even if it's already installed system-wide,
+# so that we can cache the vcpkg dirs in the CI env.
 def ensure_vcpkg():
     if not os.path.exists("vcpkg"):
         get_vcpkg()

--- a/scripts/lib/vcpkg.py
+++ b/scripts/lib/vcpkg.py
@@ -28,10 +28,6 @@ def install():
 
 
 def ensure_vcpkg():
-    if cmd_utils.has_command("vcpkg"):
-        print("Using system vcpkg")
-        return "vcpkg"
-
     if not os.path.exists("vcpkg"):
         get_vcpkg()
     else:

--- a/scripts/lib/vcpkg.py
+++ b/scripts/lib/vcpkg.py
@@ -27,8 +27,9 @@ def install():
     cmd_utils.run([vcpkg_bin, "install"], print_cmd=True)
 
 
-# Install a local vcpkg even if it's already installed system-wide,
-# so that we can cache the vcpkg dirs in the CI env.
+# Install a local vcpkg even if it's already installed system-wide, so that we can cache the
+# vcpkg dirs in the CI env. We also depend on the local `vcpkg/buildtrees` dir when bundling
+# the `openssl.exe` binary on Windows (that said, we could also use cmake to search for it).
 def ensure_vcpkg():
     if not os.path.exists("vcpkg"):
         get_vcpkg()

--- a/scripts/lib/vcpkg.py
+++ b/scripts/lib/vcpkg.py
@@ -28,6 +28,10 @@ def install():
 
 
 def ensure_vcpkg():
+    if cmd_utils.has_command("vcpkg"):
+        print("Using system vcpkg")
+        return "vcpkg"
+
     if not os.path.exists("vcpkg"):
         get_vcpkg()
     else:

--- a/scripts/lib/vcpkg.py
+++ b/scripts/lib/vcpkg.py
@@ -1,0 +1,60 @@
+# Synergy -- mouse and keyboard sharing utility
+# Copyright (C) 2024 Symless Ltd.
+#
+# This package is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# found in the file LICENSE that should have accompanied this file.
+#
+# This package is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import git  # type: ignore
+import lib.env as env
+import lib.cmd_utils as cmd_utils
+
+GIT_REPO = "https://github.com/microsoft/vcpkg.git"
+
+
+def install():
+    vcpkg_bin = ensure_vcpkg()
+
+    cmd_utils.run([vcpkg_bin, "install"], print_cmd=True)
+
+
+def ensure_vcpkg():
+    if not os.path.exists("vcpkg"):
+        get_vcpkg()
+    else:
+        print("Updating vcpkg...")
+        repo = git.Repo("vcpkg")
+        repo.remotes.origin.pull()
+
+    if env.is_windows():
+        vcpkg_bin = "vcpkg/vcpkg.exe"
+    else:
+        vcpkg_bin = "vcpkg/vcpkg"
+
+    if not os.path.exists(vcpkg_bin):
+        raise RuntimeError(f"Path not found: {vcpkg_bin}")
+
+    return vcpkg_bin
+
+
+def get_vcpkg():
+    print("Downloading vcpkg...")
+    repo = git.Repo.clone_from(GIT_REPO, "vcpkg")
+
+    os.chdir("vcpkg")
+    try:
+        if env.is_windows():
+            cmd_utils.run("bootstrap-vcpkg.bat", shell=True, print_cmd=True)
+        else:
+            cmd_utils.run("./bootstrap-vcpkg.sh", shell=True, print_cmd=True)
+    finally:
+        os.chdir("..")

--- a/scripts/lib/windows.py
+++ b/scripts/lib/windows.py
@@ -186,58 +186,15 @@ def run_codesign(path, cert_base64, cert_password):
 class WindowsChoco:
     """Chocolatey for Windows."""
 
-    def install(self, command, ci_env):
-        """Installs packages using Chocolatey."""
-        if ci_env:
-            # don't show noisy choco progress bars in ci env
-            cmd_utils.run(
-                f"{command} --no-progress",
-                shell=True,
-                print_cmd=True,
-            )
-        else:
-            self.ensure_choco_installed()
-
-            cmd_utils.run(
-                command,
-                shell=True,
-                print_cmd=True,
-            )
-
-    def config_ci_cache(self):
-        """Configures Chocolatey cache for CI."""
-
-        runner_temp = os.environ.get(RUNNER_TEMP_ENV)
-        if runner_temp:
-            # sets the choco cache dir, which should match the dir in the ci cache action.
-            key_arg = '--name="cacheLocation"'
-            value_arg = f'--value="{runner_temp}/choco"'
-            cmd_utils.run(
-                ["choco", "config", "set", key_arg, value_arg],
-                print_cmd=True,
-            )
-        else:
-            print(f"Warning: CI environment variable {RUNNER_TEMP_ENV} not set")
-
-    def remove_from_config(self, choco_config_file, remove_packages):
-        """Removes a package from the Chocolatey configuration."""
-
-        tree = ET.parse(choco_config_file)
-        root = tree.getroot()
-        for remove in remove_packages:
-            for package in root.findall("package"):
-                if package.get("id") == remove:
-                    root.remove(package)
-                    print(f"Removed package from choco config: {remove}")
-
-        tree.write(choco_config_file)
-
     def ensure_choco_installed(self):
         if cmd_utils.has_command("choco"):
             return
 
         if not cmd_utils.has_command("winget"):
-            print("The winget command was not found", file=sys.stderr)
+            print(
+                "The winget command was not found, please install Chocolatey manually",
+                file=sys.stderr,
+            )
             sys.exit(1)
 
         print("The choco command was not found, installing Chocolatey...")

--- a/scripts/lib/windows.py
+++ b/scripts/lib/windows.py
@@ -19,21 +19,55 @@ import lib.cmd_utils as cmd_utils
 import lib.env as env
 from lib.certificate import Certificate
 
-msbuild_cmd = "msbuild"
-signtool_cmd = "signtool"
-certutil_cmd = "certutil"
-runner_temp_env_var = "RUNNER_TEMP"
-dist_dir = "dist"
-build_dir = "build"
-wix_solution_file = f"{build_dir}/installer/Synergy.sln"
-installer_file = f"{build_dir}/installer/bin/Release/Synergy.msi"
+LOCK_FILE = "tmp/elevated.lock"
+MSBUILD_CMD = "msbuild"
+SIGNTOOL_CMD = "signtool"
+CERTUTIL_CMD = "certutil"
+RUNNER_TEMP_ENV = "RUNNER_TEMP"
+DIST_DIR = "dist"
+BUILD_DIR = "build"
+WIX_FILE = f"{BUILD_DIR}/installer/Synergy.sln"
+MSI_FILE = f"{BUILD_DIR}/installer/bin/Release/Synergy.msi"
 
 
-def relaunch_as_admin(script):
-    args = " ".join(sys.argv[1:])
-    command = f"{script} --pause-on-exit {args}"
-    print(f"Re-launching script as admin: {command}")
-    ctypes.windll.shell32.ShellExecuteW(None, "runas", sys.executable, command, None, 1)
+def run_elevated(script, args=None, use_sys_argv=True):
+    if not args and use_sys_argv:
+        args = " ".join(sys.argv[1:])
+
+    env.persist_lock_file(LOCK_FILE)
+    command = f"{script} --pause-on-exit --lock-file {LOCK_FILE} {args}"
+    print(f"Running script with elevated privileges: {command}")
+
+    WINDOW_HANDLE = None
+    OPERATION = "runas"
+    DIRECTORY = None
+    SHOW_CMD = 1
+    instance = ctypes.windll.shell32.ShellExecuteW(
+        WINDOW_HANDLE, OPERATION, sys.executable, command, DIRECTORY, SHOW_CMD
+    )
+
+    ERROR_ACCESS_DENIED = 5
+    if instance == ERROR_ACCESS_DENIED:
+        raise RuntimeError(
+            f"Failed to run script with elevated privileges, access denied (code {instance})"
+        )
+
+    ERROR_MAX = 32
+    if instance <= ERROR_MAX:
+        raise RuntimeError(
+            f"Failed to run script with elevated privileges, error code: {instance}"
+        )
+
+    print("Script is running with elevated privileges")
+
+    with open(LOCK_FILE, "r") as f:
+        pid = f.read()
+
+    print(f"Waiting for elevated process to exit: {pid}")
+    while os.path.exists(LOCK_FILE):
+        # Intentionally wait forever, since this code should not run where a developer
+        # has no control, such as in a CI environment.
+        pass
 
 
 def is_admin():
@@ -91,11 +125,11 @@ def build_msi(filename_base):
     configuration = "Release"
     platform = "x64"
 
-    assert_vs_cmd(msbuild_cmd)
+    assert_vs_cmd(MSBUILD_CMD)
     cmd_utils.run(
         [
-            msbuild_cmd,
-            wix_solution_file,
+            MSBUILD_CMD,
+            WIX_FILE,
             f"/p:Configuration={configuration}",
             f"/p:Platform={platform}",
         ],
@@ -104,17 +138,17 @@ def build_msi(filename_base):
     )
 
     path = get_package_path(filename_base)
-    print(f"Copying MSI installer to {dist_dir}")
-    os.makedirs(dist_dir, exist_ok=True)
-    shutil.copy(installer_file, path)
+    print(f"Copying MSI installer to {DIST_DIR}")
+    os.makedirs(DIST_DIR, exist_ok=True)
+    shutil.copy(MSI_FILE, path)
 
 
 def get_package_path(filename_base):
-    return f"{dist_dir}/{filename_base}.msi"
+    return f"{DIST_DIR}/{filename_base}.msi"
 
 
 def sign_binaries(cert_base64, cert_password):
-    exe_pattern = f"{build_dir}/bin/*.exe"
+    exe_pattern = f"{BUILD_DIR}/bin/*.exe"
     run_codesign(exe_pattern, cert_base64, cert_password)
 
 
@@ -129,12 +163,12 @@ def run_codesign(path, cert_base64, cert_password):
 
     with Certificate(cert_base64, "pfx") as cert_path:
         print("Signing MSI installer...")
-        assert_vs_cmd(signtool_cmd)
+        assert_vs_cmd(SIGNTOOL_CMD)
 
         # WARNING: contains private key password, never print this command
         cmd_utils.run(
             [
-                signtool_cmd,
+                SIGNTOOL_CMD,
                 "sign",
                 "/f",
                 cert_path,
@@ -173,7 +207,7 @@ class WindowsChoco:
     def config_ci_cache(self):
         """Configures Chocolatey cache for CI."""
 
-        runner_temp = os.environ.get(runner_temp_env_var)
+        runner_temp = os.environ.get(RUNNER_TEMP_ENV)
         if runner_temp:
             # sets the choco cache dir, which should match the dir in the ci cache action.
             key_arg = '--name="cacheLocation"'
@@ -183,7 +217,7 @@ class WindowsChoco:
                 print_cmd=True,
             )
         else:
-            print(f"Warning: CI environment variable {runner_temp_env_var} not set")
+            print(f"Warning: CI environment variable {RUNNER_TEMP_ENV} not set")
 
     def remove_from_config(self, choco_config_file, remove_packages):
         """Removes a package from the Chocolatey configuration."""

--- a/scripts/lib/windows.py
+++ b/scripts/lib/windows.py
@@ -1,3 +1,18 @@
+# Synergy -- mouse and keyboard sharing utility
+# Copyright (C) 2024 Symless Ltd.
+#
+# This package is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# found in the file LICENSE that should have accompanied this file.
+#
+# This package is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import ctypes, sys, os, shutil
 import xml.etree.ElementTree as ET
 import lib.cmd_utils as cmd_utils

--- a/scripts/lib/windows.py
+++ b/scripts/lib/windows.py
@@ -137,24 +137,6 @@ def run_codesign(path, cert_base64, cert_password):
 class WindowsChoco:
     """Chocolatey for Windows."""
 
-    def install(self, command, ci_env):
-        """Installs packages using Chocolatey."""
-        if ci_env:
-            # don't show noisy choco progress bars in ci env
-            cmd_utils.run(
-                f"{command} --no-progress",
-                shell=True,
-                print_cmd=True,
-            )
-        else:
-            self.ensure_choco_installed()
-
-            cmd_utils.run(
-                command,
-                shell=True,
-                print_cmd=True,
-            )
-
     def config_ci_cache(self):
         """Configures Chocolatey cache for CI."""
 
@@ -184,24 +166,7 @@ class WindowsChoco:
         tree.write(choco_config_file)
 
     def ensure_choco_installed(self):
-        if cmd_utils.has_command("choco"):
-            return
-
-        if not cmd_utils.has_command("winget"):
-            print("The winget command was not found", file=sys.stderr)
-            sys.exit(1)
-
-        print("The choco command was not found, installing Chocolatey...")
-        cmd_utils.run(
-            "winget install chocolatey",
-            check=False,
-            shell=True,
-            print_cmd=True,
-        )
-
         if not cmd_utils.has_command("choco"):
-            print(
-                "The choco command was still not found, please re-run this script...",
-                file=sys.stderr,
+            raise RuntimeError(
+                "The choco command was not found, please install Chocolatey"
             )
-            sys.exit(1)

--- a/scripts/lint_clang.py
+++ b/scripts/lint_clang.py
@@ -1,5 +1,20 @@
 #!/usr/bin/env python3
 
+# Synergy -- mouse and keyboard sharing utility
+# Copyright (C) 2024 Symless Ltd.
+#
+# This package is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# found in the file LICENSE that should have accompanied this file.
+#
+# This package is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import lib.env as env
 
 env.ensure_in_venv(__file__)

--- a/scripts/lint_cmake.py
+++ b/scripts/lint_cmake.py
@@ -1,5 +1,20 @@
 #!/usr/bin/env python3
 
+# Synergy -- mouse and keyboard sharing utility
+# Copyright (C) 2024 Symless Ltd.
+#
+# This package is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# found in the file LICENSE that should have accompanied this file.
+#
+# This package is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import lib.env as env
 
 env.ensure_in_venv(__file__)

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -1,5 +1,20 @@
 #!/usr/bin/env python3
 
+# Synergy -- mouse and keyboard sharing utility
+# Copyright (C) 2024 Symless Ltd.
+#
+# This package is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# found in the file LICENSE that should have accompanied this file.
+#
+# This package is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import lib.env as env
 
 env.ensure_in_venv(__file__)

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -12,4 +12,5 @@ dependencies = [
   "aqtinstall; sys_platform == 'win32' or sys_platform == 'darwin'",
   "colorama",
   "meson",
+  "gitpython",
 ]

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -1,5 +1,20 @@
 #!/usr/bin/env python3
 
+# Synergy -- mouse and keyboard sharing utility
+# Copyright (C) 2024 Symless Ltd.
+#
+# This package is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# found in the file LICENSE that should have accompanied this file.
+#
+# This package is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import lib.env as env
 
 env.ensure_in_venv(__file__)

--- a/src/lib/gui/tls/TlsCertificate.cpp
+++ b/src/lib/gui/tls/TlsCertificate.cpp
@@ -51,7 +51,7 @@ QString openSslWindowsDir() {
   // in production, openssl is deployed with the app.
   // in development, we can use the openssl path available at compile-time.
   if (!openSslDir.exists()) {
-    openSslDir = QDir(OPENSSL_PATH);
+    openSslDir = QDir(OPENSSL_EXE_DIR);
   }
 
   // if the path still isn't found, something is seriously wrong.

--- a/src/lib/net/CMakeLists.txt
+++ b/src/lib/net/CMakeLists.txt
@@ -22,10 +22,12 @@ if(ADD_HEADERS_TO_SOURCES)
 endif()
 
 add_library(net STATIC ${sources})
+
 target_link_libraries(
   net
-  PUBLIC OpenSSL::SSL
+  PUBLIC ${OPENSSL_LIBRARIES}
   PRIVATE mt io)
+
 if(WIN32)
   target_link_libraries(net PRIVATE Crypt32 ws2_32)
 endif()

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "4e08971f3ddc13018ca858a692efe92d3b6b9fce",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": [
+    "openssl"
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,10 @@
 {
   "dependencies": [
-    "openssl"
+    {
+      "name": "openssl",
+      "features": [
+        "tools"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
> Problem: There appear to be serious reliability issues with the website, slproweb.com; the maintainer will remove outdated packages and force package maintainers to race to support the latest patch. It appears that the maintainer has no intention of providing built versions of the previous patch version which all the package installers currently point to: “Stop asking me for versions of OpenSSL that have security vulnerabilities in them!” [[sic](https://slproweb.com/products/Win32OpenSSL.html)]
```
openssl v3.3.1 [Approved]
openssl package files install completed. Performing other installation steps.
Attempt to get headers for https://slproweb.com/download/Win64OpenSSL-3_3_1.exe failed.
  The remote file either doesn't exist, is unauthorized, or is forbidden for url 'https://slproweb.com/download/Win64OpenSSL-3_3_1.exe'. Exception calling "GetResponse" with "0" argument(s): "The remote server returned an error: (404) Not Found."
Downloading openssl 64 bit
  from 'https://slproweb.com/download/Win64OpenSSL-3_3_1.exe'
ERROR: The remote file either doesn't exist, is unauthorized, or is forbidden for url 'https://slproweb.com/download/Win64OpenSSL-3_3_1.exe'. Exception calling "GetResponse" with "0" argument(s): "The remote server returned an error: (404) Not Found." 
This package is likely not broken for licensed users - see https://docs.chocolatey.org/en-us/features/private-cdn.
The install of openssl was NOT successful.
```
>Solution: We should build OpenSSL ourselves using vcpkg, since this seems to offer a very recent version by default and probably has better reliability.

---
https://symless.atlassian.net/browse/S1-1833
https://symless.atlassian.net/browse/S1-1809