### PR TITLE
Only wait for elevated process to end when arg is set

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,7 @@ Enhancements:
 - #7474 FreeBSD GitHub runner with `vmactions/freebsd-vm@v1`
 - #7479 Add `BUILD.md` to get people started
 - #7485 Use `.venv` dir for as Python venv and cache
+- #7488 Only wait for elevated process to end when arg is set
 
 # 1.15.1
 

--- a/scripts/install_deps.py
+++ b/scripts/install_deps.py
@@ -222,7 +222,9 @@ class Dependencies:
 
         if not self.args.skip_elevated:
             if not windows.is_admin():
-                windows.run_elevated(__file__, "--only-elevated --skip-python")
+                windows.run_elevated(
+                    __file__, "--only-elevated --skip-python", waitForExit=True
+                )
             elif self.args.only_elevated:
                 # The choco command should run from the elevated command.
                 choco = windows.WindowsChoco()

--- a/scripts/install_deps.py
+++ b/scripts/install_deps.py
@@ -223,7 +223,7 @@ class Dependencies:
         if not self.args.skip_elevated:
             if not windows.is_admin():
                 windows.run_elevated(
-                    __file__, "--only-elevated --skip-python", waitForExit=True
+                    __file__, "--only-elevated --skip-python", wait_for_exit=True
                 )
             elif self.args.only_elevated:
                 # The choco command should run from the elevated command.

--- a/scripts/lib/windows.py
+++ b/scripts/lib/windows.py
@@ -35,9 +35,9 @@ def run_elevated(script, args=None, use_sys_argv=True, waitForExit=False):
         args = " ".join(sys.argv[1:])
 
     if waitForExit:
-        args += "--lock-file {LOCK_FILE}"
+        args += f" --lock-file {LOCK_FILE}"
+        env.persist_lock_file(LOCK_FILE)
 
-    env.persist_lock_file(LOCK_FILE)
     command = f"{script} {args} --pause-on-exit"
     print(f"Running script with elevated privileges: {command}")
 

--- a/scripts/lib/windows.py
+++ b/scripts/lib/windows.py
@@ -30,11 +30,11 @@ WIX_FILE = f"{BUILD_DIR}/installer/Synergy.sln"
 MSI_FILE = f"{BUILD_DIR}/installer/bin/Release/Synergy.msi"
 
 
-def run_elevated(script, args=None, use_sys_argv=True, waitForExit=False):
+def run_elevated(script, args=None, use_sys_argv=True, wait_for_exit=False):
     if not args and use_sys_argv:
         args = " ".join(sys.argv[1:])
 
-    if waitForExit:
+    if wait_for_exit:
         args += f" --lock-file {LOCK_FILE}"
         env.persist_lock_file(LOCK_FILE)
 
@@ -63,7 +63,7 @@ def run_elevated(script, args=None, use_sys_argv=True, waitForExit=False):
 
     print("Script is running with elevated privileges")
 
-    if waitForExit:
+    if wait_for_exit:
         with open(LOCK_FILE, "r") as f:
             pid = f.read()
 


### PR DESCRIPTION
>The command daemon.py --reinstall freezes waiting for process to stop due to the new file lock feature.

> Turn this feature off by default and allow it to be enabled with an arg.

https://symless.atlassian.net/browse/S1-1836