### PR TITLE
Use 16-CPU CI runner for FreeBSD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,7 +349,7 @@ jobs:
       SYNERGY_BUILD_CMD: |
         ./scripts/install_deps.sh;
         cmake -B build;
-        cmake --build build -j8;
+        cmake --build build -j16;
         export QT_QPA_PLATFORM=offscreen;
         ./build/bin/unittests
         ./build/bin/integtests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,7 +342,7 @@ jobs:
   # Technically, "unix" is a misnomer, but we use it here to mean "Unix-like BSD-derived".
   unix:
     name: unix-${{ matrix.distro.name }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-16-core-x64
     timeout-minutes: 20
 
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,7 +342,7 @@ jobs:
   # Technically, "unix" is a misnomer, but we use it here to mean "Unix-like BSD-derived".
   unix:
     name: unix-${{ matrix.distro.name }}
-    runs-on: ubuntu-22.04-16-core-x64
+    runs-on: ubuntu-24.04-16-core-x64
     timeout-minutes: 20
 
     env:

--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,7 @@ Enhancements:
 - #7488 Only wait for elevated process to end when arg is set
 - #7489 Add `--config-toml` arg for TOML config file
 - #7492 Add warnings for `libei` and `libportal`
+- #7495 Use 16-CPU CI runner for FreeBSD
 
 # 1.15.1
 


### PR DESCRIPTION
> Our FreeBSD runner serves an important purpose for our project, but it is the slowest runner. Part of that is the setup time, but it also seems slow to build relative to the other runners.

> An option to use all available CPUs on the host system would be helpful: https://github.com/vmactions/freebsd-vm/issues/85#issuecomment-2336596167 

https://symless.atlassian.net/browse/S1-1840

---

Special thanks to @Neilpang for improving [`vmactions/freebsd-vm`](https://github.com/vmactions/freebsd-vm) to use the maximum CPUs on the host system (https://github.com/vmactions/freebsd-vm/issues/85).
