### PR TITLE
Cache vcpkg local app dir to restore built OpenSSL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,9 @@ jobs:
       - name: Cache vcpkg dir
         uses: actions/cache@v4
         with:
-          path: vcpkg_installed
+          path: |
+            vcpkg_installed
+            ${{ env.LOCALAPPDATA }}/vcpkg
           key: vcpkg-${{ runner.os }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
           restore-keys: vcpkg-${{ runner.os }}
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,7 @@ Enhancements:
 - #7489 Add `--config-toml` arg for TOML config file
 - #7492 Add warnings for `libei` and `libportal`
 - #7495 Use 16-CPU CI runner for FreeBSD
+- #7496 Cache vcpkg local app dir to restore built OpenSSL
 
 # 1.15.1
 


### PR DESCRIPTION
> It appears that the vcpkg dep openssl is being rebuilt on Windows even though the vcpkg_installed dir is cached. This might be because it also needs the git-tree to be cached to avoid rebuilding.

> Either cache the local appdir or go back to using a local (project) install of vcpkg.

https://symless.atlassian.net/browse/S1-1842