### PR TITLE
Option to static link `libportal` ahead of 0.8.x distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,10 @@ jobs:
             runs-on: ubuntu-latest
             extra-packages: true
 
+            # Static libportal only needed until libportal is updated to 0.8.x.
+            extra-dep-args: --meson-no-system libportal --meson-static libportal --subprojects
+            extra-cmake-args: -DSYSTEM_LIBPORTAL=OFF -DSTATIC_LIBPORTAL=ON
+
           - name: debian-12-arm64
             container: symless/synergy-core:debian-12-arm64
             runs-on: ubuntu-24.04-8-core-arm64
@@ -248,6 +252,10 @@ jobs:
           - name: ubuntu-24.04-amd64
             container: symless/synergy-core:ubuntu-24.04-amd64
             runs-on: ubuntu-latest
+
+            # Static libportal only needed until libportal is updated to 0.8.x.
+            extra-dep-args: --meson-no-system libportal --meson-static libportal --subprojects
+            extra-cmake-args: -DSYSTEM_LIBPORTAL=OFF -DSTATIC_LIBPORTAL=ON
 
           - name: ubuntu-22.04-amd64
             container: symless/synergy-core:ubuntu-22.04-amd64
@@ -305,13 +313,13 @@ jobs:
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
       - name: Install dependencies
-        run: ./scripts/install_deps.py
+        run: ./scripts/install_deps.py ${{ matrix.distro.extra-dep-args }}
         env:
           # Prevent apt prompting for input.
           DEBIAN_FRONTEND: noninteractive
 
       - name: Configure
-        run: cmake -B build --preset=linux-release
+        run: cmake -B build --preset=linux-release ${{ matrix.distro.extra-cmake-args }}
 
       - name: Build
         run: cmake --build build -j8

--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,7 @@ Enhancements:
 - #7492 Add warnings for `libei` and `libportal`
 - #7495 Use 16-CPU CI runner for FreeBSD
 - #7496 Cache vcpkg local app dir to restore built OpenSSL
+- #7498 Option to static link `libportal` ahead of 0.8.x distribution
 
 # 1.15.1
 

--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -248,6 +248,12 @@ macro(configure_libportal)
     set(libportal_bin_dir
         ${CMAKE_BINARY_DIR}/meson/subprojects/libportal/libportal)
     set(libportal_src_dir ${CMAKE_SOURCE_DIR}/subprojects/libportal)
+
+    option(LIBPORTAL_STATIC "Use the static libportal binary" OFF)
+    if(LIBPORTAL_STATIC)
+      set(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+    endif()
+
     find_library(
       LIBPORTAL_LINK_LIBRARIES
       NAMES portal
@@ -258,6 +264,8 @@ macro(configure_libportal)
       message(STATUS "Using local subproject libportal")
       set(LIBPORTAL_FOUND true)
       set(LIBPORTAL_INCLUDE_DIRS ${libportal_src_dir})
+
+      message(STATUS "libportal library file: ${LIBPORTAL_LINK_LIBRARIES}")
 
       # HACK: Somehow `check_symbol_exists` doesn't pick up on the symbols even though
       # they are actually there. Since we use master branch of libportal, for now we'll

--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@ if host_machine.system() == 'windows'
   subproject('wintoast')
 endif
 
-system_gtest = get_option('system_gtest')
+system_gtest = get_option('system-gtest')
 if system_gtest
   dependency('gtest', required: false)
 else
@@ -21,7 +21,7 @@ endif
 
 if host_machine.system() == 'linux'
 
-  system_libei = get_option('system_libei')
+  system_libei = get_option('system-libei')
   if system_libei
     dependency('libei-1.0', required: false)
   else
@@ -31,11 +31,15 @@ if host_machine.system() == 'linux'
     subproject('libei', default_options: ['tests=disabled', 'liboeffis=disabled'])
   endif
 
-  system_libportal = get_option('system_libportal')
+  system_libportal = get_option('system-libportal')
   if system_libportal
     dependency('libportal', required: false)
   else
     # Using the subproject is only useful for development; it's not intended for normal use.
-    subproject('libportal', default_options: ['docs=false', 'backend-gtk3=enabled', 'backend-qt6=disabled'])
+    subproject('libportal', default_options: [
+      'docs=false',
+      'backend-gtk3=enabled',
+      'backend-qt6=disabled'
+    ])
   endif
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,3 @@
-option('system_gtest', type: 'boolean', value: true, description: 'Use system gtest')
-option('system_libportal', type: 'boolean', value: true, description: 'Use system libportal')
-option('system_libei', type: 'boolean', value: true, description: 'Use system libei')
+option('system-gtest', type: 'boolean', value: true, description: 'Use system gtest')
+option('system-libportal', type: 'boolean', value: true, description: 'Use system libportal')
+option('system-libei', type: 'boolean', value: true, description: 'Use system libei')

--- a/scripts/install_deps.py
+++ b/scripts/install_deps.py
@@ -84,7 +84,9 @@ def parse_args(is_ci):
         "--skip-meson", action="store_true", help="Do not setup and compile with Meson"
     )
     parser.add_argument(
-        "--subproject", type=str, help="Sub-project to install dependencies for"
+        "--subprojects",
+        action="store_true",
+        help="Install dependencies for Meson subprojects (use with --meson-no-system)",
     )
     parser.add_argument(
         "--meson-install",
@@ -167,11 +169,6 @@ def install(args):
         deps = Dependencies(args)
         deps.install()
 
-    if args.subproject:
-        deps = SubprojectDependencies(args.subproject)
-        deps.install()
-        return
-
     # Only install vcpkg dependencies on Windows, since on other OS it's not needed (yet).
     # We probably won't ever need this on macOS and Linux since brew and apt/dnf/etc do a
     # good job of providing dependencies. Where they don't, we can use Meson.
@@ -181,6 +178,11 @@ def install(args):
         vcpkg.install()
 
     if not args.skip_meson:
+        if args.subprojects:
+            for subproject in args.meson_no_system or []:
+                deps = SubprojectDependencies(subproject)
+                deps.install()
+
         run_meson(args.meson_install, args.meson_no_system, args.meson_static)
 
 

--- a/scripts/install_deps.py
+++ b/scripts/install_deps.py
@@ -96,6 +96,11 @@ def parse_args(is_ci):
         nargs="+",
         help="Specify which Meson subprojects to use instead of system dependencies",
     )
+    parser.add_argument(
+        "--meson-static",
+        nargs="+",
+        help="Specify which Meson subprojects to build as static libraries",
+    )
 
     if env.is_windows():
         parser.add_argument(
@@ -176,15 +181,15 @@ def install(args):
         vcpkg.install()
 
     if not args.skip_meson:
-        run_meson(args.meson_install, args.meson_no_system)
+        run_meson(args.meson_install, args.meson_no_system, args.meson_static)
 
 
 # It's a bit weird to use Meson just for installing deps, but it's a stopgap until
 # we fully switch from CMake to Meson. For the meantime, Meson will install the deps
 # so that CMake can find them easily. Once we switch to Meson, it might be possible for
 # Meson handle the deps resolution, so that we won't need to install them on the system.
-def run_meson(install, no_system_list):
-    meson.setup(no_system_list)
+def run_meson(install, no_system_list, static_list):
+    meson.setup(no_system_list, static_list)
 
     # Only compile and install on Linux for now, since we're only using Meson to fetch
     # the deps on Windows and macOS.

--- a/scripts/lib/meson.py
+++ b/scripts/lib/meson.py
@@ -45,12 +45,12 @@ def setup(no_system_list, static_list):
 
 def static_subproject(subproject):
     if subproject == "libportal":
-        # HACK: This is a bit horrible. Ideally, Meson would take care of this, but for some reason
-        # meson `patch_directory` isn't working for the libportal subproject.
+        # HACK: This is a bit horrible. Ideally, Meson would take care of applying this patch,
+        # but it only seems to copy the .diff over and not apply the patch.
+        #
         # Important: Static linking is not intended for package maintainers, only for beta testers.
         # Static linking is also pretty horrible, but many distros will be slow to pick up 0.8.x
-        # which has input capture support.
-        # The sooner we can remove this patching code the better.
+        # which has input capture support. The sooner we can remove this patching code the better.
         cmd_utils.run(
             [
                 "patch",

--- a/scripts/lib/meson.py
+++ b/scripts/lib/meson.py
@@ -61,6 +61,7 @@ def static_subproject(subproject):
                 "static-lib.diff",
             ],
             print_cmd=True,
+            check=False,
         )
     else:
         raise Exception(f"Unknown subproject: {subproject}")

--- a/scripts/lib/meson.py
+++ b/scripts/lib/meson.py
@@ -64,7 +64,7 @@ def static_subproject(subproject):
             check=False,
         )
     else:
-        raise Exception(f"Unknown subproject: {subproject}")
+        raise RuntimeError(f"Unknown subproject: {subproject}")
 
 
 def compile():

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -2,8 +2,9 @@
 *
 
 # Except for the wrap files.
-!.gitignore
-!*.wrap
+!/.gitignore
+!/*.wrap
+!/packagefiles
 
 # Ignore wraps added by subprojects.
 /gi-docgen.wrap

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -2,10 +2,10 @@
 *
 
 # Except for the wrap files.
-!/.gitignore
-!/*.wrap
-!/packagefiles
+!.gitignore
+!*.wrap
+!packagefiles/*
 
 # Ignore wraps added by subprojects.
-/gi-docgen.wrap
-/munit.wrap
+gi-docgen.wrap
+munit.wrap

--- a/subprojects/libportal.wrap
+++ b/subprojects/libportal.wrap
@@ -1,3 +1,4 @@
 [wrap-git]
 url = https://github.com/flatpak/libportal.git
 revision = main
+patch_directory = libportal

--- a/subprojects/packagefiles/libportal/static-lib.diff
+++ b/subprojects/packagefiles/libportal/static-lib.diff
@@ -1,0 +1,15 @@
+diff --git a/libportal/meson.build b/libportal/meson.build
+index 316bd9c..37a17f7 100644
+--- a/libportal/meson.build
++++ b/libportal/meson.build
+@@ -73,9 +73,8 @@ gio_unix_dep = dependency('gio-unix-2.0')
+ 
+ install_headers(headers, subdir: 'libportal')
+ 
+-libportal = library('portal',
++libportal = static_library('portal',
+   src,
+-  version: version,
+   include_directories: [top_inc, libportal_inc],
+   install: true,
+   dependencies: [gio_dep, gio_unix_dep],

--- a/subprojects/packagefiles/wintoast-patch/meson.build
+++ b/subprojects/packagefiles/wintoast-patch/meson.build
@@ -1,5 +1,0 @@
-project('wintoast', 'cpp', version : '1.3.0')
-
-wintoast_dep = declare_dependency(
-  include_directories : include_directories('.')
-)

--- a/subprojects/packagefiles/wintoast/meson.build
+++ b/subprojects/packagefiles/wintoast/meson.build
@@ -1,0 +1,5 @@
+project('wintoast', 'cpp', version : '1.3.0')
+
+wintoast_dep = declare_dependency(
+  include_directories : include_directories('.')
+)

--- a/subprojects/wintoast.wrap
+++ b/subprojects/wintoast.wrap
@@ -3,4 +3,4 @@ directory = WinToast-1.3.0
 source_url = https://github.com/mohabouje/WinToast/archive/refs/tags/v1.3.0.tar.gz
 source_filename = wintoast-1.3.0.tar.gz
 source_hash = 998bd82fb2f49ee4b0df98774424d72c2bc18225188f251a9242af28bb80e6d4
-patch_directory = wintoast-patch
+patch_directory = wintoast


### PR DESCRIPTION
> Beta testers won’t be able to try Wayland server support until libportal 0.8.x lands in the package repos. Some rolling distros like Arch are cutting-edge and already have 0.8.x, so they are not a problem, but Ubuntu and Debian can take some time.

> If we bundle libportal by statically linking it, we can allow beta testers to start testing Wayland server support early.

https://symless.atlassian.net/browse/S1-1830