### PR TITLE
Make package filenames consistent with previous versions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+# 1.16.1
+
+Enhancements:
+
+- #7503 Make package filenames consistent with previous versions
+
 # 1.16.0
 
 Enhancements:

--- a/cspell.json
+++ b/cspell.json
@@ -63,6 +63,7 @@
     "synergyd",
     "synergys",
     "trackpad",
+    "Trixie",
     "unittests",
     "Valgrind",
     "vcpkg",

--- a/scripts/lib/env.py
+++ b/scripts/lib/env.py
@@ -58,7 +58,8 @@ def get_linux_distro():
     os_file = "/etc/os-release"
     name = None
     name_like = None
-    version = None
+    version_id = None
+    version_codename = None
 
     if os.path.isfile(os_file):
         with open(os_file) as f:
@@ -68,9 +69,11 @@ def get_linux_distro():
                 elif line.startswith("ID_LIKE="):
                     name_like = line.strip().split("=")[1].strip('"')
                 elif line.startswith("VERSION_ID="):
-                    version = line.strip().split("=")[1].strip('"')
+                    version_id = line.strip().split("=")[1].strip('"')
+                elif line.startswith("VERSION_CODENAME="):
+                    version_codename = line.strip().split("=")[1].strip('"')
 
-    return name, name_like, version
+    return name, name_like, version_id or version_codename
 
 
 def get_env(name, required=True, default=None):

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -69,12 +69,20 @@ def get_filename_base(version, use_linux_distro=True):
             os_part = f"{distro_name}-{version_for_filename}"
         else:
             os_part = distro_name
+
+        # For consistency with existing filenames, we'll use 'amd64' instead of 'x86_64'.
+        # Also, that's what Linux distros tend to call that architecture anyway.
+        if machine == "x86_64":
+            machine = "amd64"
     else:
         # Some Windows users get confused by 'amd64' and think it's 'arm64',
         # so we'll use Intel's 'x64' branding (even though it's wrong).
-        if machine == "amd64":
+        # Also replace 'x86_64' with 'x64' for consistency.
+        if machine == "amd64" or machine == "x86_64":
             machine = "x64"
 
+    # Underscore is used to delimit different parts of the filename (e.g. version, OS, etc).
+    # Dashes are used to delimit spaces, e.g. "debian-trixie" for "Debian Trixie".
     return f"{package_base}_{version}_{os_part}_{machine}"
 
 

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -57,6 +57,7 @@ def get_filename_base(version, use_linux_distro=True):
     os = env.get_os()
     machine = platform.machine().lower()
     package_base = env.get_env("SYNERGY_PACKAGE_PREFIX", default=default_package_prefix)
+    os_part = os
 
     if os == "linux" and use_linux_distro:
         distro_name, _distro_like, distro_version = env.get_linux_distro()
@@ -65,18 +66,16 @@ def get_filename_base(version, use_linux_distro=True):
 
         if distro_version:
             version_for_filename = distro_version.replace(".", "_")
-            distro = f"{distro_name}-{version_for_filename}"
+            os_part = f"{distro_name}-{version_for_filename}"
         else:
-            distro = distro_name
-
-        return f"{package_base}-{distro}-{machine}-{version}"
+            os_part = distro_name
     else:
-        # some windows users get confused by 'amd64' and think it's 'arm64',
-        # so we'll use intel's 'x64' branding (even though it's wrong).
+        # Some Windows users get confused by 'amd64' and think it's 'arm64',
+        # so we'll use Intel's 'x64' branding (even though it's wrong).
         if machine == "amd64":
             machine = "x64"
 
-        return f"{package_base}-{os}-{machine}-{version}"
+    return f"{package_base}_{version}_{os_part}_{machine}"
 
 
 def windows_package(filename_base):

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -65,7 +65,7 @@ def get_filename_base(version, use_linux_distro=True):
             raise RuntimeError("Failed to detect Linux distro")
 
         if distro_version:
-            version_for_filename = distro_version.replace(".", "_")
+            version_for_filename = distro_version.replace(".", "-")
             os_part = f"{distro_name}-{version_for_filename}"
         else:
             os_part = distro_name


### PR DESCRIPTION
> The Debian package does not contain the version codename (e.g. “trixie”) so the Debian version is ambiguous.
> Add the version codename to the package to differentiate it from the Debian 12 package.
https://symless.atlassian.net/browse/S1-1845

> When rebuilding the S1 CI, the S3 filename style was copied without realizing that it is different to the S1 style, so now the S1 style in 1.15+ no longer matches 1.14 and below.
> The filename style should match between versions, so we should restore the old filename.
https://symless.atlassian.net/browse/S1-1849