### PR TITLE
Remove static link of libportal from Debian Trixie CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,10 +235,6 @@ jobs:
             runs-on: ubuntu-latest
             extra-packages: true
 
-            # Static libportal only needed until libportal is updated to 0.8.x.
-            extra-dep-args: --meson-no-system libportal --meson-static libportal --subprojects
-            extra-cmake-args: -DSYSTEM_LIBPORTAL=OFF -DSTATIC_LIBPORTAL=ON
-
           - name: debian-12-arm64
             container: symless/synergy-core:debian-12-arm64
             runs-on: ubuntu-24.04-8-core-arm64

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@
 
 Enhancements:
 
+- #7505 Remove static link in CI to libportal on Debian 13
 - #7503 Make package filenames consistent with previous versions
 
 # 1.16.0

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,8 +2,8 @@
 
 Enhancements:
 
-- #7505 Remove static link in CI to libportal on Debian 13
 - #7503 Make package filenames consistent with previous versions
+- #7505 Remove static link of libportal from Debian Trixie CI
 
 # 1.16.0
 


### PR DESCRIPTION
> Debian 13 trixie now has libportal 0.8, so no need to static link.
> https://symless.atlassian.net/browse/S1-1848