### PR TITLE
Make `APPLE_CODESIGN_ID` env var optional for CE CI

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ Enhancements:
 
 - #7503 Make package filenames consistent with previous versions
 - #7505 Remove static link of libportal from Debian Trixie CI
+- #7506 Make `APPLE_CODESIGN_ID` env var optional for CE CI
 
 # 1.16.0
 


### PR DESCRIPTION
> The community edition CI workflow fails because there is no APPLE_CODESIGN_ID env var set.

> Do not sign the bundle if the APPLE_CODESIGN_ID env var is not set.

https://symless.atlassian.net/browse/S1-1850