### PR TITLE
Add `run-retry` action to workaround `integtest` `gcovr` issue

### DIFF
--- a/.github/actions/run-retry/action.yml
+++ b/.github/actions/run-retry/action.yml
@@ -1,0 +1,31 @@
+name: "Retry command"
+description: "Retries a specified command up to a specified number of times."
+inputs:
+  run:
+    description: "The command to run"
+    required: true
+  retries:
+    description: "Number of retries"
+    required: false
+    default: 3
+runs:
+  using: "composite"
+  steps:
+    - name: Run Command with Retry
+      shell: bash
+      run: |
+        command="${{ inputs.run }}"
+        retries=${{ inputs.retries }}
+        delay=${{ inputs.delay }}
+        attempt=1
+
+        until $command; do
+          if [ $attempt -ge $retries ]; then
+            echo "Attempt $attempt failed! No more retries left."
+            exit 1
+          fi
+          echo "Attempt $attempt failed! Retrying in $delay seconds..."
+          attempt=$((attempt + 1))
+        done
+
+        echo "Command succeeded on attempt $attempt."

--- a/.github/workflows/sonarcloud-analysis.yml
+++ b/.github/workflows/sonarcloud-analysis.yml
@@ -78,6 +78,7 @@ jobs:
           QT_QPA_PLATFORM: offscreen
         run: cmake --build build --target coverage-unittests
 
+      # Retry integtests coverae as gcovr intermittently fails to parse .gcda files.
       - name: Integration tests coverage
         env:
           QT_QPA_PLATFORM: offscreen

--- a/.github/workflows/sonarcloud-analysis.yml
+++ b/.github/workflows/sonarcloud-analysis.yml
@@ -81,7 +81,9 @@ jobs:
       - name: Integration tests coverage
         env:
           QT_QPA_PLATFORM: offscreen
-        run: cmake --build build --target coverage-integtests
+        uses: ./.github/actions/run-retry
+        with:
+          run: cmake --build build --target coverage-integtests
 
       - name: Get coverage report paths
         id: coverage-paths

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ Enhancements:
 - #7503 Make package filenames consistent with previous versions
 - #7505 Remove static link of libportal from Debian Trixie CI
 - #7506 Make `APPLE_CODESIGN_ID` env var optional for CE CI
+- #7507 Add `run-retry` action to workaround `integtest` `gcovr` issue
 
 # 1.16.0
 


### PR DESCRIPTION
https://symless.atlassian.net/browse/S1-1844

Random failure on SonarCloud integtest step, e.g.:

https://github.com/symless/synergy/actions/runs/10789939224/job/29924012244 

```
[       OK ] ConfigTests.load_noArgs_returnsFalse (0 ms)
[----------] 8 tests from ConfigTests (1 ms total)

[----------] Global test environment tear-down
[==========] 18 tests from 5 test suites ran. (655 ms total)
[  PASSED  ] 18 tests.
(INFO) Reading coverage data...
(WARNING) Unrecognized GCOV output for /__w/synergy/synergy/src/lib/arch/unix/ArchMultithreadPosix.cpp
	  branch  2 taken -1
	This is indicative of a gcov output parse error.
	Please report this to the gcovr developers
	at <https://github.com/gcovr/gcovr/issues>.
(WARNING) Exception during parsing:
	NegativeHits: Got negative hit value in gcov line 'branch  2 taken -1' caused by a bug in gcov tool, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option --gcov-ignore-parse-errors with a value of negative_hits.warn, or negative_hits.warn_once_per_file.
(ERROR) Exiting because of parse errors.
	You can run gcovr with --gcov-ignore-parse-errors
	to continue anyway.
(WARNING) Unrecognized GCOV output for /__w/synergy/synergy/src/lib/arch/unix/ArchMultithreadPosix.cpp
	  branch  2 taken -1
	This is indicative of a gcov output parse error.
	Please report this to the gcovr developers
	at <https://github.com/gcovr/gcovr/issues>.
(WARNING) Exception during parsing:
	NegativeHits: Got negative hit value in gcov line 'branch  2 taken -1' caused by a bug in gcov tool, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option --gcov-ignore-parse-errors with a value of negative_hits.warn, or negative_hits.warn_once_per_file.
(ERROR) Exiting because of parse errors.
	You can run gcovr with --gcov-ignore-parse-errors
	to continue anyway.
(WARNING) Unrecognized GCOV output for /__w/synergy/synergy/src/lib/arch/unix/ArchMultithreadPosix.cpp
	  branch  2 taken -1
	This is indicative of a gcov output parse error.
	Please report this to the gcovr developers
	at <https://github.com/gcovr/gcovr/issues>.
(WARNING) Exception during parsing:
	NegativeHits: Got negative hit value in gcov line 'branch  2 taken -1' caused by a bug in gcov tool, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option --gcov-ignore-parse-errors with a value of negative_hits.warn, or negative_hits.warn_once_per_file.
(ERROR) Exiting because of parse errors.
	You can run gcovr with --gcov-ignore-parse-errors
	to continue anyway.
(ERROR) GCOV produced the following errors processing /__w/synergy/synergy/build/src/lib/arch/CMakeFiles/arch.dir/unix/ArchMultithreadPosix.cpp.gcda:
	Trouble processing '/__w/synergy/synergy/build/src/lib/arch/CMakeFiles/arch.dir/unix/ArchMultithreadPosix.cpp.gcda' with working directory '/__w/synergy/synergy/build/src/lib/arch/CMakeFiles/arch.dir/unix/.'.
Stdout of gcov was >>File '/usr/include/c++/11/ext/new_allocator.h'
Lines executed:72.73% of 11
Branches executed:50.00% of 4
Taken at least once:25.00% of 4
Calls executed:60.00% of 5
Creating 'new_allocator.h##9eebda2913f9130e95accd5845b9af9f.gcov'
...
```