### PR TITLE
Use GitHub vars to determine custom runner names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,13 @@ jobs:
       matrix:
         target:
           - name: windows-2022-x64
-            runs-on: windows-2022-8-core-x64
+            runs-on: ${{ vars.WINDOWS_RUNNER || 'windows-2022' }}
 
     steps:
+      - if: ${{ vars.USE_LARGE_RUNNERS == 'true' && matrix.target.runner-large == null }}
+        name: Skip job
+        run: echo "Skipping job as large runner is not available."
+
       - name: Checkout
         uses: actions/checkout@v4
 


### PR DESCRIPTION
> When a contributor forks our repo and enables workflows, jobs are not run because they do not have access to a runner with the names specified (i.e. paid-for large runners).

> Allow the large runners to be turned on/off for a project.

https://symless.atlassian.net/browse/S1-1851