### PR TITLE
Include .exe when comparing binary names in Windows watchdog

### DIFF
--- a/src/lib/platform/MSWindowsWatchdog.cpp
+++ b/src/lib/platform/MSWindowsWatchdog.cpp
@@ -55,9 +55,9 @@ HANDLE openProcessForKill(const PROCESSENTRY32 &entry)
   if (entry.th32ProcessID == 0)
     return nullptr;
 
-  if (_stricmp(entry.szExeFile, CLIENT_BINARY_NAME) != 0 && //
-      _stricmp(entry.szExeFile, SERVER_BINARY_NAME) != 0 && //
-      _stricmp(entry.szExeFile, CORE_BINARY_NAME) != 0) {
+  if (_stricmp(entry.szExeFile, CLIENT_BINARY_NAME ".exe") != 0 && //
+      _stricmp(entry.szExeFile, SERVER_BINARY_NAME ".exe") != 0 && //
+      _stricmp(entry.szExeFile, CORE_BINARY_NAME ".exe") != 0) {
     return nullptr;
   }
 


### PR DESCRIPTION
https://symless.atlassian.net/browse/S1-1938