### PR TITLE
Revert "Account for more modifiers in the EI keymap calculation (#94)"

### DIFF
--- a/src/lib/platform/EiKeyState.cpp
+++ b/src/lib/platform/EiKeyState.cpp
@@ -131,21 +131,6 @@ std::uint32_t EiKeyState::convert_mod_mask(std::uint32_t xkb_mask) const
     if ((xkb_mask & (1 << xkbmod)) == 0)
       continue;
 
-    /* added in libxkbcommon 1.8.0 in the same commit so we have all or none */
-#ifndef XKB_VMOD_NAME_ALT
-#define XKB_VMOD_NAME_ALT "Alt"
-#define XKB_VMOD_NAME_HYPER "Hyper"
-#define XKB_VMOD_NAME_LEVEL3 "LevelThree"
-#define XKB_VMOD_NAME_LEVEL5 "LevelFive"
-#define XKB_VMOD_NAME_META "Meta"
-#define XKB_VMOD_NAME_NUM "NumLock"
-#define XKB_VMOD_NAME_SCROLL "ScrollLock"
-#define XKB_VMOD_NAME_SUPER "Super"
-#define XKB_MOD_NAME_MOD5 "Mod5"
-#define XKB_MOD_NAME_MOD2 "Mod2"
-#define XKB_MOD_NAME_MOD3 "Mod3"
-#endif
-
     const char *name = xkb_keymap_mod_get_name(xkb_keymap_, xkbmod);
     if (strcmp(XKB_MOD_NAME_SHIFT, name) == 0)
       barrier_mask |= (1 << kKeyModifierBitShift);
@@ -153,26 +138,10 @@ std::uint32_t EiKeyState::convert_mod_mask(std::uint32_t xkb_mask) const
       barrier_mask |= (1 << kKeyModifierBitCapsLock);
     else if (strcmp(XKB_MOD_NAME_CTRL, name) == 0)
       barrier_mask |= (1 << kKeyModifierBitControl);
-    else if (strcmp(XKB_MOD_NAME_ALT, name) == 0 || strcmp(XKB_VMOD_NAME_ALT, name) == 0)
+    else if (strcmp(XKB_MOD_NAME_ALT, name) == 0)
       barrier_mask |= (1 << kKeyModifierBitAlt);
-    else if (strcmp(XKB_MOD_NAME_LOGO, name) == 0 || strcmp(XKB_VMOD_NAME_SUPER, name) == 0)
+    else if (strcmp(XKB_MOD_NAME_LOGO, name) == 0)
       barrier_mask |= (1 << kKeyModifierBitSuper);
-    else if (strcmp(XKB_MOD_NAME_MOD5, name) == 0 || strcmp(XKB_VMOD_NAME_LEVEL3, name) == 0)
-      barrier_mask |= (1 << kKeyModifierBitAltGr);
-    else if (strcmp(XKB_VMOD_NAME_LEVEL5, name) == 0)
-      barrier_mask |= (1 << kKeyModifierBitLevel5Lock);
-    else if (strcmp(XKB_VMOD_NAME_META, name) == 0)
-      barrier_mask |= (1 << kKeyModifierBitMeta);
-    else if (strcmp(XKB_VMOD_NAME_NUM, name) == 0)
-      barrier_mask |= (1 << kKeyModifierBitNumLock);
-    else if (strcmp(XKB_VMOD_NAME_SCROLL, name) == 0)
-      barrier_mask |= (1 << kKeyModifierBitScrollLock);
-    else if (strcmp(XKB_MOD_NAME_MOD2, name) == 0) // spare, sometimes mapped to num lock.
-      LOG_DEBUG2("modifier mask %s ignored", name);
-    else if (strcmp(XKB_MOD_NAME_MOD3, name) == 0) // spare, could be mapped to alt_r, caps lock, scroll lock, etc.
-      LOG_DEBUG2("modifier mask %s ignored", name);
-    else
-      LOG_WARN("modifier mask %s not accounted for, this is a bug", name);
   }
 
   return barrier_mask;


### PR DESCRIPTION
This reverts commit 0db0b32aab1d33f0619e38c83652c4a3c8f72169.

The fix causes issues such as the Alt key not working on some Wayland clients; we will reintroduce this fix once the Alt key issue is also fixed.