### PR TITLE
refactor: replace Stopwatch internals with std::chrono::steady_clock

### DIFF
--- a/src/lib/base/Stopwatch.cpp
+++ b/src/lib/base/Stopwatch.cpp
@@ -17,34 +17,21 @@
  */
 
 #include "base/Stopwatch.h"
-#include "arch/Arch.h"
 
-//
-// Stopwatch
-//
-
-Stopwatch::Stopwatch(bool triggered) : m_mark(0.0), m_triggered(triggered), m_stopped(triggered)
+Stopwatch::Stopwatch(bool triggered) : m_mark(Clock::now()), m_elapsed(0.0), m_triggered(triggered), m_stopped(triggered)
 {
-  if (!triggered) {
-    m_mark = ARCH->time();
-  }
-}
-
-Stopwatch::~Stopwatch()
-{
-  // do nothing
 }
 
 double Stopwatch::reset()
 {
   if (m_stopped) {
-    const double dt = m_mark;
-    m_mark = 0.0;
+    const double dt = m_elapsed.count();
+    m_elapsed = Duration(0.0);
     return dt;
   } else {
-    const double t = ARCH->time();
-    const double dt = t - m_mark;
-    m_mark = t;
+    const auto now = Clock::now();
+    const double dt = Duration(now - m_mark).count();
+    m_mark = now;
     return dt;
   }
 }
@@ -55,8 +42,7 @@ void Stopwatch::stop()
     return;
   }
 
-  // save the elapsed time
-  m_mark = ARCH->time() - m_mark;
+  m_elapsed = Duration(Clock::now() - m_mark);
   m_stopped = true;
 }
 
@@ -67,8 +53,9 @@ void Stopwatch::start()
     return;
   }
 
-  // set the mark such that it reports the time elapsed at stop()
-  m_mark = ARCH->time() - m_mark;
+  // resume: set mark so elapsed time is preserved
+  m_mark = Clock::now() - std::chrono::duration_cast<Clock::duration>(m_elapsed);
+  m_elapsed = Duration(0.0);
   m_stopped = false;
 }
 
@@ -81,13 +68,13 @@ void Stopwatch::setTrigger()
 double Stopwatch::getTime()
 {
   if (m_triggered) {
-    const double dt = m_mark;
+    const double dt = m_elapsed.count();
     start();
     return dt;
   } else if (m_stopped) {
-    return m_mark;
+    return m_elapsed.count();
   } else {
-    return ARCH->time() - m_mark;
+    return Duration(Clock::now() - m_mark).count();
   }
 }
 
@@ -104,9 +91,9 @@ bool Stopwatch::isStopped() const
 double Stopwatch::getTime() const
 {
   if (m_stopped) {
-    return m_mark;
+    return m_elapsed.count();
   } else {
-    return ARCH->time() - m_mark;
+    return Duration(Clock::now() - m_mark).count();
   }
 }
 

--- a/src/lib/base/Stopwatch.h
+++ b/src/lib/base/Stopwatch.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include "common/common.h"
+#include <chrono>
 
 //! A timer class
 /*!
@@ -33,7 +33,7 @@ public:
   If triggered == false then the clock starts ticking.
   */
   Stopwatch(bool triggered = false);
-  ~Stopwatch();
+  ~Stopwatch() = default;
 
   //! @name manipulators
   //@{
@@ -101,10 +101,12 @@ public:
   //@}
 
 private:
-  double getClock() const;
+  using Clock = std::chrono::steady_clock;
+  using TimePoint = Clock::time_point;
+  using Duration = std::chrono::duration<double>;
 
-private:
-  double m_mark;
+  TimePoint m_mark;
+  Duration m_elapsed{0.0};
   bool m_triggered;
   bool m_stopped;
 };

--- a/src/test/unittests/base/StopwatchTests.cpp
+++ b/src/test/unittests/base/StopwatchTests.cpp
@@ -1,0 +1,123 @@
+/*
+ * Deskflow -- mouse and keyboard sharing utility
+ * Copyright (C) 2025 Symless Ltd.
+ *
+ * This package is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * found in the file LICENSE that should have accompanied this file.
+ *
+ * This package is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "base/Stopwatch.h"
+
+#include <gtest/gtest.h>
+#include <thread>
+
+TEST(StopwatchTests, defaultCtor_startsRunning)
+{
+  Stopwatch sw;
+  EXPECT_FALSE(sw.isStopped());
+}
+
+TEST(StopwatchTests, triggeredCtor_startsStopped)
+{
+  Stopwatch sw(true);
+  EXPECT_TRUE(sw.isStopped());
+}
+
+TEST(StopwatchTests, getTime_returnsElapsed)
+{
+  Stopwatch sw;
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  double t = sw.getTime();
+  EXPECT_GE(t, 0.04);
+  EXPECT_LE(t, 0.5);
+}
+
+TEST(StopwatchTests, reset_returnsElapsedAndRestartsFromZero)
+{
+  Stopwatch sw;
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  double elapsed = sw.reset();
+  EXPECT_GE(elapsed, 0.04);
+
+  double afterReset = sw.getTime();
+  EXPECT_LT(afterReset, 0.05);
+}
+
+TEST(StopwatchTests, stop_freezesTime)
+{
+  Stopwatch sw;
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  sw.stop();
+  double t1 = sw.getTime();
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  double t2 = sw.getTime();
+  EXPECT_DOUBLE_EQ(t1, t2);
+  EXPECT_TRUE(sw.isStopped());
+}
+
+TEST(StopwatchTests, startAfterStop_resumesFromElapsed)
+{
+  Stopwatch sw;
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  sw.stop();
+  double frozen = sw.getTime();
+
+  sw.start();
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  double resumed = sw.getTime();
+
+  EXPECT_GT(resumed, frozen);
+}
+
+TEST(StopwatchTests, resetWhileStopped_returnsElapsedAndZeroes)
+{
+  Stopwatch sw;
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  sw.stop();
+  double elapsed = sw.reset();
+  EXPECT_GE(elapsed, 0.04);
+
+  double afterReset = sw.getTime();
+  EXPECT_DOUBLE_EQ(afterReset, 0.0);
+}
+
+TEST(StopwatchTests, setTrigger_stopsAndAutoStartsOnGetTime)
+{
+  Stopwatch sw;
+  sw.setTrigger();
+  EXPECT_TRUE(sw.isStopped());
+
+  double t = sw.getTime();
+  EXPECT_FALSE(sw.isStopped());
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  double t2 = sw.getTime();
+  EXPECT_GE(t2, 0.04);
+}
+
+TEST(StopwatchTests, operatorDouble_matchesGetTime)
+{
+  Stopwatch sw;
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  sw.stop();
+  double fromOp = static_cast<double>(sw);
+  double fromGet = sw.getTime();
+  EXPECT_DOUBLE_EQ(fromOp, fromGet);
+}
+
+TEST(StopwatchTests, constGetTime_doesNotTrigger)
+{
+  Stopwatch sw(true);
+  const Stopwatch &ref = sw;
+  double t = ref.getTime();
+  EXPECT_TRUE(sw.isStopped());
+}


### PR DESCRIPTION
## Summary
- Replaces the platform-specific `Arch::time()` calls inside `Stopwatch` with `std::chrono::steady_clock`
- Keeps `Stopwatch` as a thin wrapper for API compatibility
- Removes dependency on the arch layer for time measurement

## Motivation
`std::chrono::steady_clock` is the standard monotonic clock. Using it directly removes platform-specific time code and makes `Stopwatch` self-contained.

## To test:
1. `cmake -S . -B build`
2. `cmake --build build --config Release`
3. Verify zero warnings
4. Run existing tests: `ctest --test-dir build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)