### PR TITLE
Update CI workflow for package type and S3 upload URI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ env:
   SYNERGY_VERSION_RELEASE: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.package-type == 'release') }}
 
   # Used to determine the version number format (should set the stage part to "snapshot").
-  SYNERGY_VERSION_SNAPSHOT: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.package-type == 'snapshot') }}
+  SYNERGY_VERSION_SNAPSHOT: ${{ github.event_name == 'push' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.package-type == 'snapshot') }}
 
   # Gotcha: GitHub checks out a detached head, so the local SHA is not the real head SHA.
   SYNERGY_VERSION_GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
Enhance the CI workflow by introducing a new input for package type, allowing options for snapshot, release, or dev. Update the S3 upload process to use a unified URI format for better organization of uploaded files.