### PR TITLE
fix: scroll wheel lag and missing horizontal scroll on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,10 @@ deskflow-config.toml
 /scripts/*.egg-info
 /*.user
 *.ui.autosave
+
+# local docs
+*.pdf
+PR147-FEEDBACK.md
+NIH-REFACTOR.md
+WAYLAND.md
+WHEREWELEFTOFF.md

--- a/src/lib/client/ServerProxy.cpp
+++ b/src/lib/client/ServerProxy.cpp
@@ -47,10 +47,13 @@ ServerProxy::ServerProxy(Client *client, deskflow::IStream *stream, IEventQueue 
       m_seqNum(0),
       m_compressMouse(false),
       m_compressMouseRelative(false),
+      m_compressWheel(false),
       m_xMouse(0),
       m_yMouse(0),
       m_dxMouse(0),
       m_dyMouse(0),
+      m_xDeltaWheel(0),
+      m_yDeltaWheel(0),
       m_ignoreMouse(false),
       m_keepAliveAlarm(0.0),
       m_keepAliveAlarmTimer(NULL),
@@ -392,6 +395,12 @@ void ServerProxy::flushCompressedMouse()
     m_dxMouse = 0;
     m_dyMouse = 0;
   }
+  if (m_compressWheel) {
+    m_compressWheel = false;
+    m_client->mouseWheel(m_xDeltaWheel, m_yDeltaWheel);
+    m_xDeltaWheel = 0;
+    m_yDeltaWheel = 0;
+  }
 }
 
 void ServerProxy::sendInfo(const ClientInfo &info)
@@ -514,8 +523,11 @@ void ServerProxy::enter()
   // discard old compressed mouse motion, if any
   m_compressMouse = false;
   m_compressMouseRelative = false;
+  m_compressWheel = false;
   m_dxMouse = 0;
   m_dyMouse = 0;
+  m_xDeltaWheel = 0;
+  m_yDeltaWheel = 0;
   m_seqNum = seqNum;
   m_serverLanguage = "";
   m_isUserNotifiedAboutLanguageSyncError = false;
@@ -729,15 +741,24 @@ void ServerProxy::mouseRelativeMove()
 
 void ServerProxy::mouseWheel()
 {
-  // get mouse up to date
-  flushCompressedMouse();
-
   // parse
   SInt16 xDelta, yDelta;
   ProtocolUtil::readf(m_stream, kMsgDMouseWheel + 4, &xDelta, &yDelta);
+
+  if (!m_compressWheel && m_stream->isReady()) {
+    m_compressWheel = true;
+  }
+
+  if (m_compressWheel) {
+    m_xDeltaWheel += xDelta;
+    m_yDeltaWheel += yDelta;
+    return;
+  }
+
   LOG((CLOG_DEBUG2 "recv mouse wheel %+d,%+d", xDelta, yDelta));
 
-  // forward
+  flushCompressedMouse();
+
   m_client->mouseWheel(xDelta, yDelta);
 }
 

--- a/src/lib/client/ServerProxy.h
+++ b/src/lib/client/ServerProxy.h
@@ -139,8 +139,10 @@ private:
 
   bool m_compressMouse;
   bool m_compressMouseRelative;
+  bool m_compressWheel;
   SInt32 m_xMouse, m_yMouse;
   SInt32 m_dxMouse, m_dyMouse;
+  SInt32 m_xDeltaWheel, m_yDeltaWheel;
 
   bool m_ignoreMouse;
 

--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -328,7 +328,9 @@ void MSWindowsDesks::fakeMouseRelativeMove(SInt32 dx, SInt32 dy) const
 
 void MSWindowsDesks::fakeMouseWheel(SInt32 xDelta, SInt32 yDelta) const
 {
-  sendMessage(DESKFLOW_MSG_FAKE_WHEEL, xDelta, yDelta);
+  if (m_activeDesk != NULL && m_activeDesk->m_window != NULL) {
+    PostThreadMessage(m_activeDesk->m_threadID, DESKFLOW_MSG_FAKE_WHEEL, xDelta, yDelta);
+  }
 }
 
 void MSWindowsDesks::sendMessage(UINT msg, WPARAM wParam, LPARAM lParam) const
@@ -720,7 +722,9 @@ void MSWindowsDesks::deskThread(void *vdesk)
       break;
 
     case DESKFLOW_MSG_FAKE_WHEEL:
-      // XXX -- add support for x-axis scrolling
+      if (msg.wParam != 0) {
+        send_mouse_input(MOUSEEVENTF_HWHEEL, 0, 0, (DWORD)msg.wParam);
+      }
       if (msg.lParam != 0) {
         send_mouse_input(MOUSEEVENTF_WHEEL, 0, 0, (DWORD)msg.lParam);
       }

--- a/src/lib/platform/MSWindowsHook.cpp
+++ b/src/lib/platform/MSWindowsHook.cpp
@@ -510,7 +510,12 @@ static bool mouseHookHandler(WPARAM wParam, SInt32 x, SInt32 y, SInt32 data)
 
   case WM_MOUSEWHEEL:
     if (g_mode == kHOOK_RELAY_EVENTS) {
-      // relay event
+      PostThreadMessage(g_threadID, DESKFLOW_MSG_MOUSE_WHEEL, 0, data);
+    }
+    return (g_mode == kHOOK_RELAY_EVENTS);
+
+  case WM_MOUSEHWHEEL:
+    if (g_mode == kHOOK_RELAY_EVENTS) {
       PostThreadMessage(g_threadID, DESKFLOW_MSG_MOUSE_WHEEL, data, 0);
     }
     return (g_mode == kHOOK_RELAY_EVENTS);

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -985,8 +985,7 @@ bool MSWindowsScreen::onPreDispatchPrimary(HWND, UINT message, WPARAM wParam, LP
     return onMouseMove(static_cast<SInt32>(wParam), static_cast<SInt32>(lParam));
 
   case DESKFLOW_MSG_MOUSE_WHEEL:
-    // XXX -- support x-axis scrolling
-    return onMouseWheel(0, static_cast<SInt32>(wParam));
+    return onMouseWheel(static_cast<SInt32>(wParam), static_cast<SInt32>(lParam));
 
   case DESKFLOW_MSG_PRE_WARP: {
     // save position to compute delta of next motion


### PR DESCRIPTION
## Summary
- Smooth-scroll mice (Logitech, etc.) generate 100+ wheel events per second,
  causing cascading input lag that freezes the client
- Horizontal scroll was never captured or injected on Windows

## Changes
- Compress wheel events the same way mouse motion is already compressed
- Make wheel injection non-blocking (was waiting for a round-trip per tick)
- Capture and inject horizontal scroll (WM_MOUSEHWHEEL / MOUSEEVENTF_HWHEEL)

## To test
1. Connect a smooth-scroll mouse (e.g. Logitech MX Master) to the server
2. Move cursor to a client machine
3. Scroll quickly in a long document -- should be smooth with no lag or freezing
4. Tilt the scroll wheel sideways (horizontal scroll) in a wide spreadsheet
   or horizontally-scrollable page -- should scroll horizontally
5. Repeat with a standard notched-wheel mouse to confirm no regression