### PR TITLE
[Feat/Windows] Added support for horizontal scrolling 

### DIFF
--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -720,7 +720,9 @@ void MSWindowsDesks::deskThread(void *vdesk)
       break;
 
     case DESKFLOW_MSG_FAKE_WHEEL:
-      // XXX -- add support for x-axis scrolling
+      if (msg.wParam != 0) {
+        send_mouse_input(MOUSEEVENTF_HWHEEL, 0, 0, (DWORD)msg.wParam);
+      }
       if (msg.lParam != 0) {
         send_mouse_input(MOUSEEVENTF_WHEEL, 0, 0, (DWORD)msg.lParam);
       }

--- a/src/lib/platform/MSWindowsHook.cpp
+++ b/src/lib/platform/MSWindowsHook.cpp
@@ -510,7 +510,12 @@ static bool mouseHookHandler(WPARAM wParam, SInt32 x, SInt32 y, SInt32 data)
 
   case WM_MOUSEWHEEL:
     if (g_mode == kHOOK_RELAY_EVENTS) {
-      // relay event
+      PostThreadMessage(g_threadID, DESKFLOW_MSG_MOUSE_WHEEL, 0, data);
+    }
+    return (g_mode == kHOOK_RELAY_EVENTS);
+
+  case WM_MOUSEHWHEEL:
+    if (g_mode == kHOOK_RELAY_EVENTS) {
       PostThreadMessage(g_threadID, DESKFLOW_MSG_MOUSE_WHEEL, data, 0);
     }
     return (g_mode == kHOOK_RELAY_EVENTS);

--- a/src/lib/platform/MSWindowsHook.cpp
+++ b/src/lib/platform/MSWindowsHook.cpp
@@ -510,12 +510,14 @@ static bool mouseHookHandler(WPARAM wParam, SInt32 x, SInt32 y, SInt32 data)
 
   case WM_MOUSEWHEEL:
     if (g_mode == kHOOK_RELAY_EVENTS) {
+      // relay event
       PostThreadMessage(g_threadID, DESKFLOW_MSG_MOUSE_WHEEL, 0, data);
     }
     return (g_mode == kHOOK_RELAY_EVENTS);
 
   case WM_MOUSEHWHEEL:
     if (g_mode == kHOOK_RELAY_EVENTS) {
+      // relay event
       PostThreadMessage(g_threadID, DESKFLOW_MSG_MOUSE_WHEEL, data, 0);
     }
     return (g_mode == kHOOK_RELAY_EVENTS);

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -985,8 +985,7 @@ bool MSWindowsScreen::onPreDispatchPrimary(HWND, UINT message, WPARAM wParam, LP
     return onMouseMove(static_cast<SInt32>(wParam), static_cast<SInt32>(lParam));
 
   case DESKFLOW_MSG_MOUSE_WHEEL:
-    // XXX -- support x-axis scrolling
-    return onMouseWheel(0, static_cast<SInt32>(wParam));
+    return onMouseWheel(static_cast<SInt32>(wParam), static_cast<SInt32>(lParam));
 
   case DESKFLOW_MSG_PRE_WARP: {
     // save position to compute delta of next motion


### PR DESCRIPTION
### Summary
Add support for Horizontal scroll on Windows bu capturing the WM_MOUSEHWHEEL event.

### Changes
Added support for capturing WM_MOUSEHWHEEL event and then relay it to the client.

### To test
- Connect a mouse with horizontal scroll wheel (e.g. Logitech MX, Dell MS900) to the server
- Move cursor to a client machine
- Scroll horizontally on a wide spreadsheet or a large page that is horizontally scrollable.

### Edit: Testing
Tested working on 2 windows clients (`Kerberos` - server, `Surface-Studio` - client)
- Log file: [Synergy.log](https://github.com/user-attachments/files/26314738/Synergy.log) 
- Pastebin link with same logs (for security concerns with downloading the logfile): https://pastebin.com/2zu6U0Bw

I see DEBUG1 statements, onMouseWheel working with both `x, y` for `horizontal, vertical` scroll respectively.
```
[2026-03-27T14:45:24] DEBUG1: event: button wheel delta=-120,+0
[2026-03-27T14:45:24] DEBUG1: onMouseWheel -120,+0
[2026-03-27T14:45:24] DEBUG1: event: button wheel delta=+0,+120
[2026-03-27T14:45:24] DEBUG1: onMouseWheel +0,+120
```
