### PR TITLE
Add a screen setting that keeps media and volume keys on the server

### DIFF
--- a/src/gui/src/ScreenSettingsDialog.cpp
+++ b/src/gui/src/ScreenSettingsDialog.cpp
@@ -75,6 +75,7 @@ ScreenSettingsDialog::ScreenSettingsDialog(QWidget *parent, Screen *pScreen, con
   m_pCheckBoxXTest->setChecked(m_pScreen->fix(XTest));
 
   m_pLineEditAnchoredKeys->setText(m_pScreen->anchoredKeys());
+  m_pCheckBoxAnchorMediaKeys->setChecked(m_pScreen->anchorMediaKeys());
 }
 
 void ScreenSettingsDialog::accept()
@@ -125,6 +126,7 @@ void ScreenSettingsDialog::accept()
   m_pScreen->setFix(static_cast<int>(XTest), m_pCheckBoxXTest->isChecked());
 
   m_pScreen->setAnchoredKeys(m_pLineEditAnchoredKeys->text());
+  m_pScreen->setAnchorMediaKeys(m_pCheckBoxAnchorMediaKeys->isChecked());
 
   QDialog::accept();
 }

--- a/src/gui/src/ScreenSettingsDialogBase.ui
+++ b/src/gui/src/ScreenSettingsDialogBase.ui
@@ -757,6 +757,13 @@ Comma-separated. Use + for combos (e.g. Alt+Tab, Ctrl+A).</string>
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QCheckBox" name="m_pCheckBoxAnchorMediaKeys">
+        <property name="text">
+         <string>Anchor media keys to server (play, stop, next, prev, volume)</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/lib/gui/config/Screen.cpp
+++ b/src/lib/gui/config/Screen.cpp
@@ -77,6 +77,7 @@ void Screen::loadSettings(QSettingsProxy &settings)
   readSettings(settings, fixes(), "fix", 0, static_cast<int>(NumFixes));
 
   setAnchoredKeys(settings.value("anchoredKeys").toString());
+  setAnchorMediaKeys(settings.value("anchorMediaKeys").toBool());
 }
 
 void Screen::saveSettings(QSettingsProxy &settings) const
@@ -94,6 +95,7 @@ void Screen::saveSettings(QSettingsProxy &settings) const
   writeSettings(settings, fixes(), "fix");
 
   settings.setValue("anchoredKeys", anchoredKeys());
+  settings.setValue("anchorMediaKeys", anchorMediaKeys());
 }
 
 QTextStream &Screen::writeScreensSection(QTextStream &outStream) const
@@ -117,9 +119,18 @@ QTextStream &Screen::writeScreensSection(QTextStream &outStream) const
   outStream << "\t\t"
             << "switchCornerSize = " << switchCornerSize() << Qt::endl;
 
-  if (!anchoredKeys().isEmpty())
-    outStream << "\t\t"
-              << "anchoredKeys = " << anchoredKeys() << Qt::endl;
+  {
+    QString keys = anchoredKeys();
+    if (anchorMediaKeys()) {
+      QString media = "MediaPlay, MediaStop, MediaNext, MediaPrev, VolumeMute, VolumeUp, VolumeDown";
+      if (!keys.isEmpty())
+        keys += ", " + media;
+      else
+        keys = media;
+    }
+    if (!keys.isEmpty())
+      outStream << "\t\t" << "anchoredKeys = " << keys << Qt::endl;
+  }
 
   return outStream;
 }
@@ -140,6 +151,7 @@ bool Screen::operator==(const Screen &screen) const
 {
   return m_Name == screen.m_Name && m_Aliases == screen.m_Aliases && m_Modifiers == screen.m_Modifiers &&
          m_SwitchCorners == screen.m_SwitchCorners && m_SwitchCornerSize == screen.m_SwitchCornerSize &&
-         m_Fixes == screen.m_Fixes && m_AnchoredKeys == screen.m_AnchoredKeys && m_Swapped == screen.m_Swapped &&
+         m_Fixes == screen.m_Fixes && m_AnchoredKeys == screen.m_AnchoredKeys &&
+         m_AnchorMediaKeys == screen.m_AnchorMediaKeys && m_Swapped == screen.m_Swapped &&
          m_isServer == screen.m_isServer;
 }

--- a/src/lib/gui/config/Screen.h
+++ b/src/lib/gui/config/Screen.h
@@ -180,6 +180,14 @@ protected:
   {
     m_AnchoredKeys = keys;
   }
+  bool anchorMediaKeys() const
+  {
+    return m_AnchorMediaKeys;
+  }
+  void setAnchorMediaKeys(bool on)
+  {
+    m_AnchorMediaKeys = on;
+  }
 
 private:
   QPixmap m_Pixmap = QPixmap(":res/icons/64x64/video-display.png");
@@ -190,6 +198,7 @@ private:
   int m_SwitchCornerSize;
   QList<bool> m_Fixes;
   QString m_AnchoredKeys;
+  bool m_AnchorMediaKeys = false;
   bool m_Swapped = false;
   bool m_isServer = false;
 };


### PR DESCRIPTION
*Generated by Claude*

[S1-2299](https://symless.atlassian.net/browse/S1-2299)

Builds on #172; the base branch is that PR's branch.

## Test steps

1. Install this build on a Windows server with at least one client connected.
2. On the server, open Configure Server, double-click the server's screen and tick "Anchor media keys to server (play, stop, next, prev, volume)". Click OK twice and restart the server.
3. Start playing music on the server, then move the cursor to the client.
4. Press play/pause, next track and volume up on the server's keyboard.

   Expect: the server's player pauses, skips and gets louder; the client does nothing.
5. Untick the checkbox, click OK twice and restart the server, then repeat step 4 from the client.

   Expect: the media keys go to the client again.


[S1-2299]: https://symless.atlassian.net/browse/S1-2299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ