### PR TITLE
Fix macOS event queue and screen saver memory bugs

### DIFF
--- a/src/lib/platform/OSXEventQueueBuffer.cpp
+++ b/src/lib/platform/OSXEventQueueBuffer.cpp
@@ -20,6 +20,7 @@
 
 #include "base/Event.h"
 #include "base/IEventQueue.h"
+#include "base/Log.h"
 
 //
 // EventQueueTimer
@@ -33,86 +34,70 @@ class EventQueueTimer
 // OSXEventQueueBuffer
 //
 
-OSXEventQueueBuffer::OSXEventQueueBuffer(IEventQueue *events)
-    : m_event(NULL),
-      m_eventQueue(events),
-      m_carbonEventQueue(NULL)
+OSXEventQueueBuffer::OSXEventQueueBuffer(IEventQueue *events) : m_eventQueue(events)
 {
-  // do nothing
+  // Initialization is now managed using modern constructs
 }
 
 OSXEventQueueBuffer::~OSXEventQueueBuffer()
 {
-  // release the last event
-  if (m_event != NULL) {
-    ReleaseEvent(m_event);
-  }
+  // No explicit clean-up needed as GCD and STL handle resource management
 }
 
 void OSXEventQueueBuffer::init()
 {
-  m_carbonEventQueue = GetCurrentEventQueue();
+  // No initialization needed for GCD-based implementation
 }
 
 void OSXEventQueueBuffer::waitForEvent(double timeout)
 {
-  EventRef event;
-  ReceiveNextEvent(0, NULL, timeout, false, &event);
+  std::unique_lock<std::mutex> lock(m_mutex);
+  if (m_dataQueue.empty()) {
+    auto duration = std::chrono::duration<double>(timeout);
+    LOG_DEBUG2("waiting for event, timeout: %f seconds", timeout);
+    m_cond.wait_for(lock, duration, [this] { return !m_dataQueue.empty(); });
+  } else {
+    LOG_DEBUG2("found events in the queue");
+  }
 }
 
 IEventQueueBuffer::Type OSXEventQueueBuffer::getEvent(Event &event, UInt32 &dataID)
 {
-  // release the previous event
-  if (m_event != NULL) {
-    ReleaseEvent(m_event);
-    m_event = NULL;
-  }
-
-  // get the next event
-  OSStatus error = ReceiveNextEvent(0, NULL, 0.0, true, &m_event);
-
-  // handle the event
-  if (error == eventLoopQuitErr) {
-    event = Event(Event::kQuit);
-    return kSystem;
-  } else if (error != noErr) {
+  std::unique_lock<std::mutex> lock(m_mutex);
+  if (m_dataQueue.empty()) {
+    LOG_DEBUG2("no events in queue");
     return kNone;
-  } else {
-    UInt32 eventClass = GetEventClass(m_event);
-    switch (eventClass) {
-    case 'Syne':
-      dataID = GetEventKind(m_event);
-      return kUser;
-
-    default:
-      event = Event(Event::kSystem, m_eventQueue->getSystemTarget(), &m_event);
-      return kSystem;
-    }
   }
+
+  dataID = m_dataQueue.front();
+  m_dataQueue.pop();
+  lock.unlock(); // Unlock early to allow other threads to proceed
+
+  LOG_DEBUG2("handled user event with dataID: %u", dataID);
+  return kUser;
 }
 
 bool OSXEventQueueBuffer::addEvent(UInt32 dataID)
 {
-  EventRef event;
-  OSStatus error = CreateEvent(kCFAllocatorDefault, 'Syne', dataID, 0, kEventAttributeNone, &event);
+  // Use GCD to dispatch event addition on the main queue
+  dispatch_async(dispatch_get_main_queue(), ^{
+    std::lock_guard<std::mutex> lock(this->m_mutex);
+    LOG_DEBUG2("adding user event with dataID: %u", dataID);
+    this->m_dataQueue.push(dataID);
+    this->m_cond.notify_one();
+    LOG_DEBUG2("user event added to queue, dataID=%u", dataID);
+  });
 
-  if (error == noErr) {
-
-    assert(m_carbonEventQueue != NULL);
-
-    error = PostEventToQueue(m_carbonEventQueue, event, kEventPriorityStandard);
-
-    ReleaseEvent(event);
-  }
-
-  return (error == noErr);
+  // Always return true since dispatch_async does not fail under normal conditions
+  return true;
 }
 
 bool OSXEventQueueBuffer::isEmpty() const
 {
-  EventRef event;
-  OSStatus status = ReceiveNextEvent(0, NULL, 0.0, false, &event);
-  return (status == eventLoopTimedOutErr);
+  std::lock_guard<std::mutex> lock(m_mutex);
+  bool empty = m_dataQueue.empty();
+  LOG_DEBUG2("queue is %s", empty ? "empty" : "not empty");
+  return empty;
 }
 
 EventQueueTimer *OSXEventQueueBuffer::newTimer(double, bool) const

--- a/src/lib/platform/OSXEventQueueBuffer.h
+++ b/src/lib/platform/OSXEventQueueBuffer.h
@@ -20,7 +20,10 @@
 
 #include "base/IEventQueueBuffer.h"
 
-#include <Carbon/Carbon.h>
+#include <condition_variable>
+#include <dispatch/dispatch.h>
+#include <mutex>
+#include <queue>
 
 class IEventQueue;
 
@@ -32,16 +35,18 @@ public:
   virtual ~OSXEventQueueBuffer();
 
   // IEventQueueBuffer overrides
-  virtual void init();
-  virtual void waitForEvent(double timeout);
-  virtual Type getEvent(Event &event, UInt32 &dataID);
-  virtual bool addEvent(UInt32 dataID);
-  virtual bool isEmpty() const;
-  virtual EventQueueTimer *newTimer(double duration, bool oneShot) const;
-  virtual void deleteTimer(EventQueueTimer *) const;
+  virtual void init() override;
+  virtual void waitForEvent(double timeout) override;
+  virtual Type getEvent(Event &event, UInt32 &dataID) override;
+  virtual bool addEvent(UInt32 dataID) override;
+  virtual bool isEmpty() const override;
+  virtual EventQueueTimer *newTimer(double duration, bool oneShot) const override;
+  virtual void deleteTimer(EventQueueTimer *timer) const override;
 
 private:
-  EventRef m_event;
   IEventQueue *m_eventQueue;
-  EventQueueRef m_carbonEventQueue;
+
+  mutable std::mutex m_mutex;
+  std::condition_variable m_cond;
+  std::queue<UInt32> m_dataQueue;
 };

--- a/src/lib/platform/OSXScreenSaver.cpp
+++ b/src/lib/platform/OSXScreenSaver.cpp
@@ -173,11 +173,12 @@ void getProcessSerialNumber(const char *name, ProcessSerialNumber &psn)
 
 bool isScreenSaverEngine(const ProcessSerialNumber &psn)
 {
-  CFStringRef processName;
+  CFStringRef processName = nullptr;
   OSStatus err = CopyProcessName(&psn, &processName);
-  bool result = (err == 0 && CFEqual(CFSTR("ScreenSaverEngine"), processName));
-  CFRelease(processName);
-
+  const bool result = (err == 0 && CFEqual(CFSTR("ScreenSaverEngine"), processName));
+  if (processName) {
+    CFRelease(processName);
+  }
   return result;
 }
 


### PR DESCRIPTION
https://symless.atlassian.net/browse/S1-2132
https://symless.atlassian.net/browse/S1-2139

Improve memory safety by initializing `processName` to `nullptr` and ensuring safe release in `isScreenSaverEngine`. Transition event handling from Carbon to Grand Central Dispatch (GCD) for better resource management and concurrency.

Thanks @CaptainChemist