### PR TITLE
Refactor OSX event tap handling to a dedicated thread

### DIFF
--- a/src/lib/platform/OSXEventQueueBuffer.cpp
+++ b/src/lib/platform/OSXEventQueueBuffer.cpp
@@ -53,9 +53,10 @@ void OSXEventQueueBuffer::waitForEvent(double timeout)
 {
   std::unique_lock<std::mutex> lock(m_mutex);
   if (m_dataQueue.empty()) {
-    auto duration = std::chrono::duration<double>(timeout);
     LOG_DEBUG2("waiting for event, timeout: %f seconds", timeout);
-    m_cond.wait_for(lock, duration, [this] { return !m_dataQueue.empty(); });
+    auto end = timeout < 0 ? std::chrono::steady_clock::time_point::max()
+                           : std::chrono::steady_clock::now() + std::chrono::duration<double>(timeout);
+    m_cond.wait_until(lock, end, [this] { return !m_dataQueue.empty(); });
   } else {
     LOG_DEBUG2("found events in the queue");
   }

--- a/src/lib/platform/OSXScreen.h
+++ b/src/lib/platform/OSXScreen.h
@@ -33,6 +33,7 @@
 #include <mach/mach_interface.h>
 #include <mach/mach_port.h>
 #include <memory>
+#include <thread>
 
 extern "C"
 {
@@ -327,6 +328,8 @@ private:
   // Quartz input event support
   CFMachPortRef m_eventTapPort;
   CFRunLoopSourceRef m_eventTapRLSR;
+  std::thread m_eventTapThread;
+  CFRunLoopRef m_eventTapRunLoop = nullptr;
 
   // for double click coalescing.
   double m_lastClickTime;

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -44,6 +44,7 @@
 #include <AppKit/NSEvent.h>
 #include <AvailabilityMacros.h>
 #include <IOKit/hidsystem/event_status_driver.h>
+#include <dispatch/dispatch.h>
 #include <libproc.h>
 #include <mach-o/dyld.h>
 #include <math.h>
@@ -756,7 +757,20 @@ void OSXScreen::enable()
   if (m_eventTapPort) {
     m_eventTapRLSR = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, m_eventTapPort, 0);
     if (m_eventTapRLSR) {
-      CFRunLoopAddSource(CFRunLoopGetCurrent(), m_eventTapRLSR, kCFRunLoopDefaultMode);
+      // Run the event tap on a dedicated thread with its own CFRunLoop so it fires
+      // independently of whatever event loop the calling thread runs (e.g. QCoreApplication).
+      // Use a semaphore to ensure m_eventTapRunLoop is set before enable() returns.
+      auto sem = dispatch_semaphore_create(0);
+      m_eventTapThread = std::thread([this, sem]() {
+        m_eventTapRunLoop = CFRunLoopGetCurrent();
+        CFRunLoopAddSource(m_eventTapRunLoop, m_eventTapRLSR, kCFRunLoopDefaultMode);
+        dispatch_semaphore_signal(sem);
+        CFRunLoopRun();
+        CFRunLoopRemoveSource(CFRunLoopGetCurrent(), m_eventTapRLSR, kCFRunLoopDefaultMode);
+        m_eventTapRunLoop = nullptr;
+      });
+      dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
+      dispatch_release(sem);
     } else {
       LOG((CLOG_ERR "failed to create a CFRunLoopSourceRef for the quartz event tap"));
     }
@@ -771,8 +785,14 @@ void OSXScreen::disable()
 
   // FIXME -- stop watching jump zones, stop capturing input
 
+  if (m_eventTapRunLoop) {
+    CFRunLoopStop(m_eventTapRunLoop);
+  }
+  if (m_eventTapThread.joinable()) {
+    m_eventTapThread.join();
+  }
+
   if (m_eventTapRLSR) {
-    CFRunLoopRemoveSource(CFRunLoopGetCurrent(), m_eventTapRLSR, kCFRunLoopDefaultMode);
     CFRelease(m_eventTapRLSR);
     m_eventTapRLSR = nullptr;
   }


### PR DESCRIPTION
https://symless.atlassian.net/browse/S1-2138

Run the OSX event tap on a dedicated thread with its own CFRunLoop to improve responsiveness and ensure it operates independently from the main event loop. This change enhances event processing efficiency.

Thanks @Rendann