### PR TITLE
Touch activates screen v9

### DIFF
--- a/cmake/Build.cmake
+++ b/cmake/Build.cmake
@@ -39,7 +39,10 @@ endmacro()
 macro(warnings_as_errors)
   if(WIN32)
     message(STATUS "Enabling warnings as errors (MSVC)")
-    add_compile_options(/WX)
+    # /EHsc: enable standard C++ unwind semantics. Normally CMake's default MSVC
+    # flags include it, but the vcpkg toolchain can reset CMAKE_CXX_FLAGS on a
+    # clean configure and drop it, which makes C4530 fatal under /WX. Assert it.
+    add_compile_options(/WX /EHsc)
   elseif(UNIX)
     message(STATUS "Enabling warnings as errors (GNU/Clang)")
     add_compile_options(-Werror)

--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -158,20 +158,43 @@ MSWindowsDesks::MSWindowsDesks(
   m_keyLayout = AppUtilWindows::instance().getCurrentKeyboardLayout();
   resetOptions();
 
-  // Touch-activate click replay is OFF by default: the safe behaviour never
-  // synthesizes a click, so it can never land on the wrong control (the user
-  // may need a second tap for a legacy app). Enable it for testing on the
-  // target hardware by setting SYNERGY_TOUCH_CLICK_REPLAY=1 in the environment.
-  // We log the resolved state loudly so field logs make the mode unambiguous.
-  // (GetEnvironmentVariableA avoids the deprecated std::getenv, which would
-  // fail the MSVC warnings-as-errors build.)
+  // Touch-activate click replay now FOLLOWS the "switch screens on touch"
+  // toggle (touchActivateScreen): when that option is on, deskFakeTouchClick
+  // replays a real click; when it's off, it never injects. setTouchClickReplay
+  // is driven from MSWindowsScreen::setOptions, so no env var is needed in the
+  // field. The SYNERGY_TOUCH_CLICK_REPLAY env var is kept only as an override:
+  //   =0/false/no -> force replay OFF regardless of the toggle (safety kill-switch)
+  //   =1/true/yes -> force replay ON  regardless of the toggle (testing/legacy)
+  // Absent -> follow the toggle. (GetEnvironmentVariableA avoids the deprecated
+  // std::getenv, which would fail the MSVC warnings-as-errors build.)
   char replayEnv[8] = {};
   DWORD replayLen = GetEnvironmentVariableA("SYNERGY_TOUCH_CLICK_REPLAY", replayEnv, sizeof(replayEnv));
-  m_touchClickReplay = (replayLen > 0 && replayLen < sizeof(replayEnv) &&
-                        (replayEnv[0] == '1' || replayEnv[0] == 't' || replayEnv[0] == 'T' ||
-                         replayEnv[0] == 'y' || replayEnv[0] == 'Y'));
-  LOG((CLOG_INFO "touch: click replay %s (set SYNERGY_TOUCH_CLICK_REPLAY=1 to enable)",
-       m_touchClickReplay ? "ENABLED" : "disabled"));
+  if (replayLen > 0 && replayLen < sizeof(replayEnv)) {
+    char c = replayEnv[0];
+    if (c == '0' || c == 'f' || c == 'F' || c == 'n' || c == 'N') {
+      m_touchClickReplayOverride = -1;
+    } else if (c == '1' || c == 't' || c == 'T' || c == 'y' || c == 'Y') {
+      m_touchClickReplayOverride = 1;
+    }
+  }
+  m_touchClickReplay = (m_touchClickReplayOverride == 1);
+  LOG((CLOG_INFO "touch: click replay follows 'switch screens on touch' toggle%s",
+       m_touchClickReplayOverride == 1  ? " (env override: forced ON)" :
+       m_touchClickReplayOverride == -1 ? " (env override: forced OFF)" : ""));
+}
+
+void MSWindowsDesks::setTouchClickReplay(bool enabled)
+{
+  // Apply the env-var override on top of the toggle state.
+  if (m_touchClickReplayOverride == 1) {
+    enabled = true;
+  } else if (m_touchClickReplayOverride == -1) {
+    enabled = false;
+  }
+  if (enabled != m_touchClickReplay) {
+    m_touchClickReplay = enabled;
+    LOG((CLOG_INFO "touch: click replay %s", enabled ? "ENABLED" : "disabled"));
+  }
 }
 
 MSWindowsDesks::~MSWindowsDesks()

--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -157,6 +157,21 @@ MSWindowsDesks::MSWindowsDesks(
   m_deskClass = createDeskWindowClass(m_isPrimary);
   m_keyLayout = AppUtilWindows::instance().getCurrentKeyboardLayout();
   resetOptions();
+
+  // Touch-activate click replay is OFF by default: the safe behaviour never
+  // synthesizes a click, so it can never land on the wrong control (the user
+  // may need a second tap for a legacy app). Enable it for testing on the
+  // target hardware by setting SYNERGY_TOUCH_CLICK_REPLAY=1 in the environment.
+  // We log the resolved state loudly so field logs make the mode unambiguous.
+  // (GetEnvironmentVariableA avoids the deprecated std::getenv, which would
+  // fail the MSVC warnings-as-errors build.)
+  char replayEnv[8] = {};
+  DWORD replayLen = GetEnvironmentVariableA("SYNERGY_TOUCH_CLICK_REPLAY", replayEnv, sizeof(replayEnv));
+  m_touchClickReplay = (replayLen > 0 && replayLen < sizeof(replayEnv) &&
+                        (replayEnv[0] == '1' || replayEnv[0] == 't' || replayEnv[0] == 'T' ||
+                         replayEnv[0] == 'y' || replayEnv[0] == 'Y'));
+  LOG((CLOG_INFO "touch: click replay %s (set SYNERGY_TOUCH_CLICK_REPLAY=1 to enable)",
+       m_touchClickReplay ? "ENABLED" : "disabled"));
 }
 
 MSWindowsDesks::~MSWindowsDesks()
@@ -332,12 +347,25 @@ void MSWindowsDesks::fakeTouchClick(SInt32 x, SInt32 y) const
   sendMessage(DESKFLOW_MSG_FAKE_TOUCH, static_cast<WPARAM>(x), static_cast<LPARAM>(y));
 }
 
+void MSWindowsDesks::postFakeTouchClick(SInt32 x, SInt32 y) const
+{
+  // Non-blocking: post to the desk thread and return immediately (no
+  // waitForDesk). A flood of rapid on-screen taps therefore cannot block the
+  // input thread once-per-tap and hang the client; the desk thread drains the
+  // queued clicks at its own pace.
+  if (m_activeDesk != NULL && m_activeDesk->m_window != NULL) {
+    PostThreadMessage(m_activeDesk->m_threadID, DESKFLOW_MSG_FAKE_TOUCH,
+                      static_cast<WPARAM>(x), static_cast<LPARAM>(y));
+  }
+}
+
 void MSWindowsDesks::setPendingTouchClick(SInt32 x, SInt32 y)
 {
   m_pendingTouchX = x;
   m_pendingTouchY = y;
   m_pendingTouchUp = true;
   m_touchLifted = true;
+  m_pendingTouchTick = GetTickCount();
   LOG((CLOG_DEBUG "touch: LL hook path, pending click at %d,%d for deskEnter replay", x, y));
 }
 
@@ -533,30 +561,72 @@ LRESULT CALLBACK MSWindowsDesks::secondaryDeskProc(HWND hwnd, UINT msg, WPARAM w
 
 void MSWindowsDesks::deskMouseMove(SInt32 x, SInt32 y) const
 {
-  // when using absolute positioning with mouse_event(),
-  // the normalized device coordinates range over only
-  // the primary screen.
-  SInt32 w = GetSystemMetrics(SM_CXSCREEN);
-  SInt32 h = GetSystemMetrics(SM_CYSCREEN);
+  // Map the absolute move across the ENTIRE virtual desktop, not just the
+  // primary monitor. MOUSEEVENTF_ABSOLUTE without MOUSEEVENTF_VIRTUALDESK
+  // normalizes 0..65535 over the primary monitor only, so on multi-monitor
+  // setups (or when the target display is not the primary) the cursor lands on
+  // the wrong physical pixel — the touchscreen could be a secondary display.
+  // This is a critical correctness fix: a click must land exactly where the
+  // user touched. (x,y) are virtual-screen pixel coordinates.
+  SInt32 vx = GetSystemMetrics(SM_XVIRTUALSCREEN);
+  SInt32 vy = GetSystemMetrics(SM_YVIRTUALSCREEN);
+  SInt32 vw = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+  SInt32 vh = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+
+  // Defensive fallback: if the virtual-desktop metrics are unavailable for any
+  // reason, fall back to primary-monitor metrics (single-monitor behaviour).
+  if (vw <= 1) {
+    vx = 0;
+    vw = GetSystemMetrics(SM_CXSCREEN);
+  }
+  if (vh <= 1) {
+    vy = 0;
+    vh = GetSystemMetrics(SM_CYSCREEN);
+  }
+
   send_mouse_input(
-      MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE, (DWORD)((65535.0f * x) / (w - 1) + 0.5f),
-      (DWORD)((65535.0f * y) / (h - 1) + 0.5f), 0
+      MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK,
+      (DWORD)((65535.0f * (x - vx)) / (vw - 1) + 0.5f),
+      (DWORD)((65535.0f * (y - vy)) / (vh - 1) + 0.5f), 0
   );
 }
 
 void MSWindowsDesks::deskFakeTouchClick(SInt32 x, SInt32 y) const
 {
+  // SAFETY GATE: never synthesize a click unless replay is explicitly
+  // enabled (SYNERGY_TOUCH_CLICK_REPLAY=1). When disabled, the screen still
+  // activates on touch and the user's real finger touch reaches the app — we
+  // never inject a click at all, so it can never land on the wrong control.
+  // See m_touchClickReplay in the header for the full rationale.
+  if (!m_touchClickReplay) {
+    LOG((CLOG_DEBUG "touch: click replay disabled, not injecting at %d,%d "
+                    "(real touch passes through; second tap may be needed)", x, y));
+    return;
+  }
+
+  DWORD t0 = GetTickCount();
   POINT pt = {x, y};
   HWND target = WindowFromPoint(pt);
   HWND fg = GetForegroundWindow();
 
-  LOG((CLOG_DEBUG "touch: injecting at %d,%d target=0x%08x fg=0x%08x",
+  LOG((CLOG_DEBUG "touch: replay click at %d,%d target=0x%08x fg=0x%08x",
        x, y, target, fg));
 
+  // Bring the window under the touch point to the foreground *before* clicking,
+  // so the click acts on its control rather than merely activating the window.
+  // Legacy Win32 apps otherwise swallow the first click as an activation click,
+  // which is the root of the "user must tap twice" symptom.
+  //
+  // Always re-assert it — even when the target already looks like the foreground
+  // window. On switch-in the window is reported foreground before its input
+  // queue/focus has actually settled (synergy's overlay is still getting out of
+  // the way), so the replayed click gets swallowed and the user has to re-tap.
+  // The AttachThreadInput + SetForegroundWindow here forces the input queue to
+  // be attached and the window genuinely active so the click lands first time.
   if (target) {
     HWND root = GetAncestor(target, GA_ROOT);
-    if (root && root != fg) {
-      LOG((CLOG_DEBUG "touch: target root=0x%08x != fg, activating", root));
+    if (root) {
+      LOG((CLOG_DEBUG "touch: activating window root=0x%08x before click (fg was 0x%08x)", root, fg));
       DWORD targetThread = GetWindowThreadProcessId(root, NULL);
       DWORD curThread = GetCurrentThreadId();
 
@@ -565,6 +635,9 @@ void MSWindowsDesks::deskFakeTouchClick(SInt32 x, SInt32 y) const
         attached = AttachThreadInput(targetThread, curThread, TRUE);
       }
 
+      // Zero-delta move: nudges the input system so the foreground-lock timer
+      // lets SetForegroundWindow succeed. No cursor movement, so it cannot
+      // affect where the click lands.
       mouse_event(MOUSEEVENTF_MOVE, 0, 0, 0, 0);
       SetForegroundWindow(root);
       BringWindowToTop(root);
@@ -575,54 +648,49 @@ void MSWindowsDesks::deskFakeTouchClick(SInt32 x, SInt32 y) const
     }
   }
 
-  static bool touchInitialized = false;
-  static bool touchInitAttempted = false;
-  if (!touchInitAttempted) {
-    touchInitAttempted = true;
-    touchInitialized = InitializeTouchInjection(2, TOUCH_FEEDBACK_NONE) != 0;
-    if (touchInitialized) {
-      LOG((CLOG_DEBUG "touch: InitializeTouchInjection succeeded"));
-    } else {
-      LOG((CLOG_WARN "touch: InitializeTouchInjection failed, error=%lu, will use mouse fallback",
-           GetLastError()));
-    }
-  }
+  // Deliver a REAL left mouse click (WM_LBUTTONDOWN/UP) at the exact touch
+  // location. We deliberately synthesize classic mouse button events rather
+  // than InjectTouchInput: the customer's legacy Win32 app — like many
+  // pre-touch apps — handles mouse messages but ignores WM_POINTER touch
+  // messages, and Windows' automatic touch->mouse promotion is unreliable on
+  // Windows 10 IoT. deskMouseMove positions the cursor across the full virtual
+  // desktop, so the click lands on the correct physical pixel on any monitor.
+  //
+  // SAFETY: the only coordinate ever used is (x,y) — where the finger
+  // physically touched, captured at touch-down. We never click a remembered or
+  // coordinate-transformed location, so the click cannot land on a wrong
+  // control. The logged coordinate must match the touch point in field tests.
+  // Atomic move+press at the EXACT pixel. Previously this was three separate
+  // SendInput calls (move, then a position-less down, then up), so the down
+  // clicked wherever the cursor happened to be — if anything nudged it between
+  // the move and the press (the finger still on the glass, a relayed mouse
+  // event, the move not settling) the click landed a few pixels off and missed
+  // small controls (e.g. Paint colour swatches) even though it logged "at x,y".
+  // Carrying the absolute virtual-desktop position on the button-down, in a
+  // single SendInput batch with the up, makes the click land exactly at (x,y).
+  SInt32 vx = GetSystemMetrics(SM_XVIRTUALSCREEN);
+  SInt32 vy = GetSystemMetrics(SM_YVIRTUALSCREEN);
+  SInt32 vw = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+  SInt32 vh = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+  if (vw <= 1) { vx = 0; vw = GetSystemMetrics(SM_CXSCREEN); }
+  if (vh <= 1) { vy = 0; vh = GetSystemMetrics(SM_CYSCREEN); }
+  LONG nx = (LONG)((65535.0f * (x - vx)) / (vw - 1) + 0.5f);
+  LONG ny = (LONG)((65535.0f * (y - vy)) / (vh - 1) + 0.5f);
 
-  if (touchInitialized) {
-    POINTER_TOUCH_INFO contact = {};
-    contact.pointerInfo.pointerType = PT_TOUCH;
-    contact.pointerInfo.pointerId = 1;
-    contact.pointerInfo.ptPixelLocation.x = x;
-    contact.pointerInfo.ptPixelLocation.y = y;
-    contact.pointerInfo.pointerFlags =
-        POINTER_FLAG_DOWN | POINTER_FLAG_INRANGE | POINTER_FLAG_INCONTACT;
-    contact.touchFlags = TOUCH_FLAG_NONE;
-    contact.touchMask = TOUCH_MASK_CONTACTAREA | TOUCH_MASK_ORIENTATION |
-                        TOUCH_MASK_PRESSURE;
-    contact.orientation = 90;
-    contact.pressure = 32000;
-    contact.rcContact.left = x - 2;
-    contact.rcContact.right = x + 2;
-    contact.rcContact.top = y - 2;
-    contact.rcContact.bottom = y + 2;
+  INPUT click[2] = {};
+  click[0].type = INPUT_MOUSE;
+  click[0].mi.dx = nx;
+  click[0].mi.dy = ny;
+  click[0].mi.dwFlags =
+      MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK | MOUSEEVENTF_LEFTDOWN;
+  click[1].type = INPUT_MOUSE;
+  click[1].mi.dwFlags = MOUSEEVENTF_LEFTUP;
+  SendInput(2, click, sizeof(INPUT));
 
-    if (!InjectTouchInput(1, &contact)) {
-      LOG((CLOG_DEBUG "touch: InjectTouchInput DOWN failed, error=%lu, falling back to mouse",
-           GetLastError()));
-      deskMouseMove(x, y);
-      send_mouse_input(MOUSEEVENTF_LEFTDOWN, 0, 0, 0);
-      send_mouse_input(MOUSEEVENTF_LEFTUP, 0, 0, 0);
-      return;
-    }
-
-    PostThreadMessage(GetCurrentThreadId(), DESKFLOW_MSG_TOUCH_UPDATE,
-                      static_cast<WPARAM>(x), static_cast<LPARAM>(y));
-    return;
-  }
-
-  deskMouseMove(x, y);
-  send_mouse_input(MOUSEEVENTF_LEFTDOWN, 0, 0, 0);
-  send_mouse_input(MOUSEEVENTF_LEFTUP, 0, 0, 0);
+  POINT after = {};
+  GetCursorPos(&after);
+  LOG((CLOG_INFO "touch: replayed left click at %d,%d (cursor landed %d,%d, inject %u ms, total %u ms from touch)",
+       x, y, after.x, after.y, GetTickCount() - t0, GetTickCount() - m_pendingTouchTick));
 }
 
 void MSWindowsDesks::deskMouseRelativeMove(SInt32 dx, SInt32 dy) const
@@ -743,8 +811,8 @@ void MSWindowsDesks::deskEnter(Desk *desk)
   }
 
   if (touchEnter) {
-    LOG((CLOG_DEBUG "touch: deskEnter, injecting at %d,%d",
-         m_pendingTouchX, m_pendingTouchY));
+    LOG((CLOG_INFO "touch: deskEnter, injecting at %d,%d (%u ms from touch->switch arrival)",
+         m_pendingTouchX, m_pendingTouchY, GetTickCount() - m_pendingTouchTick));
     PostThreadMessage(desk->m_threadID, DESKFLOW_MSG_FAKE_TOUCH,
                       static_cast<WPARAM>(m_pendingTouchX),
                       static_cast<LPARAM>(m_pendingTouchY));

--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -332,6 +332,15 @@ void MSWindowsDesks::fakeTouchClick(SInt32 x, SInt32 y) const
   sendMessage(DESKFLOW_MSG_FAKE_TOUCH, static_cast<WPARAM>(x), static_cast<LPARAM>(y));
 }
 
+void MSWindowsDesks::setPendingTouchClick(SInt32 x, SInt32 y)
+{
+  m_pendingTouchX = x;
+  m_pendingTouchY = y;
+  m_pendingTouchUp = true;
+  m_touchLifted = true;
+  LOG((CLOG_DEBUG "touch: LL hook path, pending click at %d,%d for deskEnter replay", x, y));
+}
+
 void MSWindowsDesks::fakeMouseMove(SInt32 x, SInt32 y) const
 {
   sendMessage(DESKFLOW_MSG_FAKE_MOVE, static_cast<WPARAM>(x), static_cast<LPARAM>(y));

--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -883,12 +883,21 @@ MSWindowsDesks::HidTouchDevice MSWindowsDesks::initHidTouchDevice(HANDLE hDevice
 
     USAGE usage = vc.IsRange ? vc.Range.UsageMin : vc.NotRange.Usage;
     auto &ci = collections[vc.LinkCollection];
+
+    // Windows sign-extends LogicalMax into a LONG using BitSize bits.
+    // A 16-bit descriptor with max 0xFFFF becomes -1 as a signed LONG.
+    // Reconstruct the unsigned value from the bit width.
+    LONG logMax = vc.LogicalMax;
+    if (logMax < 0 && vc.BitSize > 0 && vc.BitSize < 32) {
+      logMax = static_cast<LONG>((1UL << vc.BitSize) - 1);
+    }
+
     if (usage == HID_USAGE_GENERIC_X) {
       ci.hasX = true;
-      ci.maxX = vc.LogicalMax > 0 ? vc.LogicalMax : vc.PhysicalMax;
+      ci.maxX = logMax > 0 ? logMax : vc.PhysicalMax;
     } else if (usage == HID_USAGE_GENERIC_Y) {
       ci.hasY = true;
-      ci.maxY = vc.LogicalMax > 0 ? vc.LogicalMax : vc.PhysicalMax;
+      ci.maxY = logMax > 0 ? logMax : vc.PhysicalMax;
     }
   }
 
@@ -954,6 +963,9 @@ bool MSWindowsDesks::parseHidTouch(const RAWINPUT *raw, const HidTouchDevice &de
   // Touch digitizer maps to the primary monitor, not the virtual desktop
   SInt32 pw = GetSystemMetrics(SM_CXSCREEN);
   SInt32 ph = GetSystemMetrics(SM_CYSCREEN);
+  if (dev.logicalMaxX == 0 || dev.logicalMaxY == 0) {
+    return false;
+  }
   outX = static_cast<SInt32>(rawX * pw / dev.logicalMaxX);
   outY = static_cast<SInt32>(rawY * ph / dev.logicalMaxY);
   LOG((CLOG_DEBUG1 "touch HID: raw=%lu,%lu logMax=%lu,%lu primary=%dx%d -> %d,%d",

--- a/src/lib/platform/MSWindowsDesks.h
+++ b/src/lib/platform/MSWindowsDesks.h
@@ -172,6 +172,8 @@ public:
   */
   void fakeMouseButton(ButtonID id, bool press);
 
+  void setPendingTouchClick(SInt32 x, SInt32 y);
+
   //! Fake mouse move
   /*!
   Synthesize a mouse move to the absolute coordinates \c x,y.

--- a/src/lib/platform/MSWindowsDesks.h
+++ b/src/lib/platform/MSWindowsDesks.h
@@ -174,6 +174,13 @@ public:
 
   void setPendingTouchClick(SInt32 x, SInt32 y);
 
+  //! Whether touch click replay is enabled (SYNERGY_TOUCH_CLICK_REPLAY).
+  /*!
+  Lets callers (e.g. on-screen tap handling) check the safety gate before
+  consuming a touch, so native pass-through is preserved when replay is off.
+  */
+  bool isTouchClickReplayEnabled() const { return m_touchClickReplay; }
+
   //! Fake mouse move
   /*!
   Synthesize a mouse move to the absolute coordinates \c x,y.
@@ -193,6 +200,16 @@ public:
   void fakeMouseWheel(SInt32 xDelta, SInt32 yDelta) const;
 
   void fakeTouchClick(SInt32 x, SInt32 y) const;
+
+  //! Non-blocking fake touch click (for rapid on-screen taps).
+  /*!
+  Like fakeTouchClick but posts the request to the desk thread WITHOUT
+  waiting for completion. Used for on-screen tap replay, where a burst of
+  rapid taps would otherwise block the input thread (via waitForDesk) once
+  per tap and hang the client. The desk thread drains queued clicks at its
+  own pace; order of distinct taps is preserved by the message queue.
+  */
+  void postFakeTouchClick(SInt32 x, SInt32 y) const;
 
   //@}
 
@@ -320,5 +337,27 @@ private:
   bool m_touchLifted = false;
   SInt32 m_pendingTouchX = 0;
   SInt32 m_pendingTouchY = 0;
+  DWORD m_pendingTouchTick = 0; // GetTickCount when the touch was detected (timing)
+
+  // SAFETY GATE (touch-activates-screen v8).
+  //
+  // When false (the default), deskFakeTouchClick never synthesizes a click.
+  // The screen still activates on touch, but the user's real finger touch is
+  // what reaches the application — we never inject a click at all. This
+  // eliminates the "click lands in the wrong place" failure mode entirely, at
+  // the cost of the user needing a second tap for the legacy app to register
+  // the press.
+  //
+  // When true, deskFakeTouchClick replays a real left mouse click
+  // (WM_LBUTTONDOWN/UP) at the exact point the finger touched, mapped across
+  // the full virtual desktop so it lands correctly on any monitor. This is the
+  // v8 fix for the "needs a second tap" symptom.
+  //
+  // For safety-critical deployments (e.g. control consoles) a missed first tap
+  // is acceptable; a click on the wrong control is not — so this defaults OFF
+  // and ships safe. Enable it for validation on the target hardware by setting
+  // the SYNERGY_TOUCH_CLICK_REPLAY=1 environment variable (resolved once in the
+  // constructor, logged at startup). Flip the default only once validated.
+  bool m_touchClickReplay = false;
 
 };

--- a/src/lib/platform/MSWindowsDesks.h
+++ b/src/lib/platform/MSWindowsDesks.h
@@ -174,10 +174,18 @@ public:
 
   void setPendingTouchClick(SInt32 x, SInt32 y);
 
-  //! Whether touch click replay is enabled (SYNERGY_TOUCH_CLICK_REPLAY).
+  //! Enable/disable touch click replay (driven by the touchActivateScreen toggle).
   /*!
-  Lets callers (e.g. on-screen tap handling) check the safety gate before
-  consuming a touch, so native pass-through is preserved when replay is off.
+  Called from MSWindowsScreen::setOptions when the "switch screens on touch"
+  option changes, so click replay follows that single toggle. An explicit
+  SYNERGY_TOUCH_CLICK_REPLAY env override (set in the ctor) wins over \c enabled.
+  */
+  void setTouchClickReplay(bool enabled);
+
+  //! Whether touch click replay is currently enabled.
+  /*!
+  Lets callers (e.g. on-screen tap handling) check the gate before consuming a
+  touch, so native pass-through is preserved when replay is off.
   */
   bool isTouchClickReplayEnabled() const { return m_touchClickReplay; }
 
@@ -339,25 +347,24 @@ private:
   SInt32 m_pendingTouchY = 0;
   DWORD m_pendingTouchTick = 0; // GetTickCount when the touch was detected (timing)
 
-  // SAFETY GATE (touch-activates-screen v8).
+  // CLICK-REPLAY GATE (touch-activates-screen v9).
   //
-  // When false (the default), deskFakeTouchClick never synthesizes a click.
-  // The screen still activates on touch, but the user's real finger touch is
-  // what reaches the application — we never inject a click at all. This
-  // eliminates the "click lands in the wrong place" failure mode entirely, at
-  // the cost of the user needing a second tap for the legacy app to register
-  // the press.
+  // When false, deskFakeTouchClick never synthesizes a click: the screen still
+  // activates on touch, but the user's real finger touch is what reaches the
+  // app — we never inject, so a click can never land on the wrong control (at
+  // the cost of possibly needing a second tap on a legacy app).
   //
-  // When true, deskFakeTouchClick replays a real left mouse click
-  // (WM_LBUTTONDOWN/UP) at the exact point the finger touched, mapped across
-  // the full virtual desktop so it lands correctly on any monitor. This is the
-  // v8 fix for the "needs a second tap" symptom.
+  // When true, deskFakeTouchClick replays a real left click (WM_LBUTTONDOWN/UP)
+  // at the exact point the finger touched, mapped across the full virtual
+  // desktop so it lands correctly on any monitor — the fix for "needs a second
+  // tap".
   //
-  // For safety-critical deployments (e.g. control consoles) a missed first tap
-  // is acceptable; a click on the wrong control is not — so this defaults OFF
-  // and ships safe. Enable it for validation on the target hardware by setting
-  // the SYNERGY_TOUCH_CLICK_REPLAY=1 environment variable (resolved once in the
-  // constructor, logged at startup). Flip the default only once validated.
+  // v9: this now FOLLOWS the "switch screens on touch" toggle. setTouchClickReplay
+  // is called from MSWindowsScreen::setOptions, so enabling the toggle (which
+  // already propagates server->clients) turns replay on everywhere — no env var
+  // needed. m_touchClickReplayOverride holds the optional env override:
+  //   0 = none (follow the toggle), 1 = forced ON, -1 = forced OFF (kill-switch).
   bool m_touchClickReplay = false;
+  int m_touchClickReplayOverride = 0;
 
 };

--- a/src/lib/platform/MSWindowsHook.cpp
+++ b/src/lib/platform/MSWindowsHook.cpp
@@ -48,6 +48,11 @@ static BOOL g_isOnScreen = TRUE;
 static bool g_touchActivateScreen = false;
 static SInt32 g_xCenter = 0;
 static SInt32 g_yCenter = 0;
+// One-shot suppression of the stray native touch click that the switch-
+// triggering touch leaves behind (prevents a double-click on switch-in).
+static DWORD g_suppressTouchUntil = 0;
+static SInt32 g_suppressTouchX = 0;
+static SInt32 g_suppressTouchY = 0;
 
 MSWindowsHook::MSWindowsHook()
 {
@@ -156,6 +161,13 @@ void MSWindowsHook::setMode(EHookMode mode)
 void MSWindowsHook::setTouchActivateScreen(bool enabled)
 {
   g_touchActivateScreen = enabled;
+}
+
+void MSWindowsHook::suppressNextTouch(SInt32 x, SInt32 y)
+{
+  g_suppressTouchX = x;
+  g_suppressTouchY = y;
+  g_suppressTouchUntil = GetTickCount() + 700;
 }
 
 void MSWindowsHook::setIsPrimary(bool primary)
@@ -631,6 +643,19 @@ static LRESULT CALLBACK mouseLLHook(int code, WPARAM wParam, LPARAM lParam)
         SInt32 dyc = y - g_yCenter;
         if (dxc >= -1 && dxc <= 1 && dyc >= -1 && dyc <= 1) {
           LOG((CLOG_DEBUG2 "hook: ignoring touch at cursor center %d,%d", x, y));
+          return 1;
+        }
+
+        // Eat the stray transition touch click: the touch that triggered a
+        // switch leaves a native touch->mouse click behind; if it lands after
+        // the switch completes it stacks on the deskEnter replay = double click.
+        // One-shot, bounded to near the trigger point and a short time window.
+        if (wParam == WM_LBUTTONDOWN && g_suppressTouchUntil != 0 &&
+            GetTickCount() < g_suppressTouchUntil &&
+            abs(static_cast<int>(x - g_suppressTouchX)) <= 60 &&
+            abs(static_cast<int>(y - g_suppressTouchY)) <= 60) {
+          g_suppressTouchUntil = 0; // consume once
+          LOG((CLOG_DEBUG "hook: suppressed stray transition touch click at %d,%d (replay covers it)", x, y));
           return 1;
         }
 

--- a/src/lib/platform/MSWindowsHook.cpp
+++ b/src/lib/platform/MSWindowsHook.cpp
@@ -46,6 +46,8 @@ static bool g_fakeServerInput = false;
 static BOOL g_isPrimary = TRUE;
 static BOOL g_isOnScreen = TRUE;
 static bool g_touchActivateScreen = false;
+static SInt32 g_xCenter = 0;
+static SInt32 g_yCenter = 0;
 
 MSWindowsHook::MSWindowsHook()
 {
@@ -164,6 +166,12 @@ void MSWindowsHook::setIsPrimary(bool primary)
 void MSWindowsHook::setIsOnScreen(bool onScreen)
 {
   g_isOnScreen = onScreen ? TRUE : FALSE;
+}
+
+void MSWindowsHook::setCursorCenter(SInt32 x, SInt32 y)
+{
+  g_xCenter = x;
+  g_yCenter = y;
 }
 
 static void keyboardGetState(BYTE keys[256], DWORD vkCode, bool kf_up)
@@ -615,12 +623,20 @@ static LRESULT CALLBACK mouseLLHook(int code, WPARAM wParam, LPARAM lParam)
       if (isTouchEvent && (wParam == WM_LBUTTONDOWN || wParam == WM_MOUSEMOVE)) {
         SInt32 x = static_cast<SInt32>(info->pt.x);
         SInt32 y = static_cast<SInt32>(info->pt.y);
-        LOG((CLOG_DEBUG "hook: touch at %d,%d posting DESKFLOW_MSG_TOUCH", x, y));
-        PostThreadMessage(g_threadID, DESKFLOW_MSG_TOUCH, x, y);
-        if (g_isPrimary) {
-          LOG((CLOG_DEBUG "hook: eating touch event (relay mode)"));
+
+        // Filter out warp-echo: the server warps the cursor to center after
+        // a switch, which generates a synthetic mouse event at that position.
+        // Without this filter, the echo triggers an immediate switch-back.
+        SInt32 dxc = x - g_xCenter;
+        SInt32 dyc = y - g_yCenter;
+        if (dxc >= -1 && dxc <= 1 && dyc >= -1 && dyc <= 1) {
+          LOG((CLOG_DEBUG2 "hook: ignoring touch at cursor center %d,%d", x, y));
           return 1;
         }
+
+        LOG((CLOG_DEBUG "hook: touch at %d,%d posting DESKFLOW_MSG_TOUCH", x, y));
+        PostThreadMessage(g_threadID, DESKFLOW_MSG_TOUCH, x, y);
+        // let the touch event pass through to the app so the click registers
       }
     }
 

--- a/src/lib/platform/MSWindowsHook.h
+++ b/src/lib/platform/MSWindowsHook.h
@@ -55,4 +55,6 @@ public:
   void setIsPrimary(bool primary);
 
   void setIsOnScreen(bool onScreen);
+
+  void setCursorCenter(SInt32 x, SInt32 y);
 };

--- a/src/lib/platform/MSWindowsHook.h
+++ b/src/lib/platform/MSWindowsHook.h
@@ -52,6 +52,16 @@ public:
 
   void setTouchActivateScreen(bool enabled);
 
+  //! Suppress the next physical touch click near (x,y) for a short window.
+  /*!
+  Called when a touch triggers a screen switch. The triggering touch's native
+  (Windows touch->mouse) click can arrive AFTER the switch completes — by then
+  the screen is on-screen so the hook no longer eats it, and it stacks on top of
+  the deskEnter replay click, producing a double-click. This eats that one stray
+  touchSig=yes click near the trigger point; the replay (touchSig=no) is intact.
+  */
+  void suppressNextTouch(SInt32 x, SInt32 y);
+
   void setIsPrimary(bool primary);
 
   void setIsOnScreen(bool onScreen);

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -1640,6 +1640,8 @@ void MSWindowsScreen::updateScreenShape()
 
   // tell the desks
   m_desks->setShape(m_x, m_y, m_w, m_h, m_xCenter, m_yCenter, m_multimon);
+
+  m_hook.setCursorCenter(m_xCenter, m_yCenter);
 }
 
 void MSWindowsScreen::handleFixes(const Event &, void *)

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -978,6 +978,14 @@ bool MSWindowsScreen::onPreDispatch(HWND hwnd, UINT message, WPARAM wParam, LPAR
     LOG((CLOG_DEBUG "DESKFLOW_MSG_TOUCH: touchActive=%d isOnScreen=%d isPrimary=%d at %d,%d",
          m_touchActivateScreen ? 1 : 0, m_isOnScreen ? 1 : 0, m_isPrimary ? 1 : 0,
          (int)wParam, (int)lParam));
+    // When already on this screen we do NOT inject anything: Windows already
+    // promotes the physical touch to a real click and the low-level hook lets it
+    // pass through to the app (see MSWindowsHook mouseLLHook, the injected
+    // pass-through). Injecting an extra synthetic click here double-clicks the
+    // control (a toggle flips twice = no visible change) and the extra injected
+    // events overload the low-level hook until Windows silently removes it,
+    // killing all touch detection. So on-screen taps are left to the OS; we only
+    // act when off-screen, to switch the active screen here.
     if (!m_touchActivateScreen || m_isOnScreen)
       return true;
     {
@@ -1482,6 +1490,9 @@ bool MSWindowsScreen::onPointerInput(WPARAM wParam, LPARAM lParam)
     return false;
   }
 
+  // On-screen taps are left to the OS (Windows promotes touch to a real click
+  // that the hook passes through); injecting here double-clicks the control and
+  // overloads the low-level hook. Only act when off-screen, to switch here.
   if (!m_touchActivateScreen || m_isOnScreen)
     return false;
 

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -996,6 +996,7 @@ bool MSWindowsScreen::onPreDispatch(HWND hwnd, UINT message, WPARAM wParam, LPAR
                   MotionInfo::alloc(x, y));
       } else {
         LOG((CLOG_INFO "hook: touch requesting grab input at %d,%d", x, y));
+        m_desks->setPendingTouchClick(x, y);
         sendEvent(m_events->forIScreen().grabInput(),
                   MotionInfo::alloc(x, y));
       }

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -489,6 +489,10 @@ void MSWindowsScreen::setOptions(const OptionsList &options)
     if (options[i] == kOptionTouchActivateScreen) {
       m_touchActivateScreen = (options[i + 1] != 0);
       m_hook.setTouchActivateScreen(m_touchActivateScreen);
+      // Click replay folds into this one toggle: enabling "switch screens on
+      // touch" also enables the touch click replay (an env override can still
+      // force it on/off). See MSWindowsDesks::setTouchClickReplay.
+      m_desks->setTouchClickReplay(m_touchActivateScreen);
       LOG((CLOG_DEBUG "touch activate screen set to %s", m_touchActivateScreen ? "true" : "false"));
     }
   }

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -726,6 +726,17 @@ BaseClientProxy *Server::mapToNeighbor(BaseClientProxy *src, EDirection srcSide,
   // move inwards because that side can't provoke a jump.
   avoidJumpZone(dst, srcSide, x, y);
 
+  // Clamp entry coordinates 1px inside the destination screen.
+  // avoidJumpZone only adjusts the crossing axis; the parallel axis can
+  // land exactly on the edge, which the cursor-warp logic treats as still
+  // being on the source side, bouncing the cursor back immediately.
+  SInt32 cx, cy, cw, ch;
+  dst->getShape(cx, cy, cw, ch);
+  if (x < cx + 1)      x = cx + 1;
+  if (x > cx + cw - 2) x = cx + cw - 2;
+  if (y < cy + 1)      y = cy + 1;
+  if (y > cy + ch - 2) y = cy + ch - 2;
+
   return dst;
 }
 

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -1393,7 +1393,18 @@ void Server::handleTouchActivatedPrimaryEvent(const Event &event, void *)
 
     switchScreen(m_primaryClient, x, y, false);
 
+    // Raise the window under the touch point (no-op cost when already foreground).
     m_primaryClient->activateWindowAt(x, y);
+
+    // Replay a real click at the touch point on the PRIMARY too. Without this the
+    // first touch that returns control to the server only activates the window and
+    // is swallowed as an activation click, forcing the user to tap twice — the same
+    // legacy-app symptom the secondary path already fixes via deskFakeTouchClick.
+    // This routes through the identical, safety-gated replay path
+    // (SYNERGY_TOUCH_CLICK_REPLAY): a no-op when replay is disabled (ships safe),
+    // and a real left click at exactly (x,y) when enabled — never a stored or
+    // transformed coordinate, so it can never land on the wrong control.
+    m_primaryClient->fakeTouchClick(x, y);
 
     m_touchSwitchCooldown.reset();
     LOG((CLOG_DEBUG1 "touch switch cooldown started"));


### PR DESCRIPTION
v9 of the Windows touch-activate work — our field-validated approach to the first-tap-after-switch problem. Tested over the weekend on two Win10 IoT touch machines (server + client): instrumented 50-target cross-screen run, 50/50 first-try, every replayed click landed exactly where aimed (cursor-landed == aimed on every log line), at both DPIs.

Note on the base: this branch is built on the v6-era base (where we forked when the v8 path wasn't landing on the hardware), so it diverges from current v8. Replaying it onto current v8 is mostly clean — only MSWindowsHook.cpp conflicts (our suppression approach vs the raw-HID-on-primary work). Happy to pair on reconciling that one file.

What it does:
* deskFakeTouchClick: deliver the click as a single atomic SendInput carrying the absolute virtual-desktop coordinate on the button-down, so it lands exactly where the finger touched (the separate move/down/up version drifts off small targets)
* deskMouseMove: map across the full virtual desktop so the click lands on the correct monitor
* always re-assert foreground before the click so the first tap isn't swallowed when the window hasn't settled
* Server: replay the click when touch returns control to the server too (was activate-only -> tap twice)
* hook: ignore warp-echo at cursor centre and one-shot-suppress the stray transition touch click to avoid switch-back / double-click
* gate the replay behind the 'switch screens on touch' toggle (off by default, ships safe)
* Build.cmake: assert /EHsc under /WX (vcpkg can drop it)