### PR TITLE
fix: cursor jumps to center of main display on multi-monitor macOS

### DIFF
--- a/src/lib/server/PrimaryClient.cpp
+++ b/src/lib/server/PrimaryClient.cpp
@@ -124,10 +124,12 @@ void PrimaryClient::disable()
 void PrimaryClient::enter(SInt32 xAbs, SInt32 yAbs, UInt32 seqNum, KeyModifierMask mask, bool screensaver)
 {
   m_screen->setSequenceNumber(seqNum);
+  // enter() first so m_isOnScreen becomes true before warpCursor triggers
+  // mouse-move events — otherwise onMouseMove re-centers the cursor
+  m_screen->enter(mask);
   if (!screensaver) {
     m_screen->warpCursor(xAbs, yAbs);
   }
-  m_screen->enter(mask);
 }
 
 bool PrimaryClient::leave()


### PR DESCRIPTION
## Summary

On a multi-monitor macOS setup (e.g. 3 screens), when switching back from a secondary machine to the primary (server) screen, the cursor sometimes jumps to the center of the main display instead of appearing at the correct position on the edge screen.

**Root cause:** In `PrimaryClient::enter()`, `warpCursor(xAbs, yAbs)` was called *before* `m_screen->enter(mask)`. The warp generates a mouse-move event that is processed by `OSXScreen::onMouseMove()` while `m_isOnScreen` is still `false`, causing the cursor to be re-warped to `m_xCenter/m_yCenter` (center of the main display).

**Fix:** Swap the call order — call `enter()` first (which sets `m_isOnScreen = true`), then `warpCursor()`. This ensures the warp-generated mouse event is handled as a normal on-screen motion rather than triggering the off-screen re-centering logic.

## Test plan

- [x] macOS server (3 monitors: 1 primary + 2 stacked right) + Windows client on right edge
- [x] Switch to Windows, move mouse around, switch back — cursor appears at correct edge position
- [x] Verified cursor no longer jumps to center of main display on return
- [x] Protocol version unchanged (v1.8), compatible with existing 1.14.x clients