### PR TITLE
fix: link failure on macOS 15+ due to missing libpthread

### DIFF
--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -126,11 +126,18 @@ macro(configure_unix_libs)
   check_type_size(short SIZEOF_SHORT)
 
   # pthread is used on both Linux and Mac
-  check_library_exists("pthread" pthread_create "" HAVE_PTHREAD)
-  if(HAVE_PTHREAD)
-    list(APPEND libs pthread)
+  if(APPLE)
+    # macOS bundles pthread in libSystem; no separate -lpthread needed
+    find_package(Threads REQUIRED)
+    list(APPEND libs Threads::Threads)
+    set(HAVE_PTHREAD 1 CACHE INTERNAL "")
   else()
-    message(FATAL_ERROR "Missing library: pthread")
+    check_library_exists("pthread" pthread_create "" HAVE_PTHREAD)
+    if(HAVE_PTHREAD)
+      list(APPEND libs pthread)
+    else()
+      message(FATAL_ERROR "Missing library: pthread")
+    endif()
   endif()
 
   if(APPLE)


### PR DESCRIPTION
## Summary

Building on macOS 15+ (Sequoia/Tahoe) with Xcode 16+ fails at link time:

```
ld: library 'pthread' not found
```

Modern macOS consolidates pthread into libSystem — there is no standalone `libpthread` to link against. The existing `check_library_exists("pthread" ...)` check passes (because `pthread_create` exists in libSystem), but the resulting `-lpthread` flag fails with the new linker.

**Fix:** On Apple platforms, use CMake's `find_package(Threads)` + `Threads::Threads` instead of raw `-lpthread`. This correctly resolves to the system threading support without requiring a standalone library. The `HAVE_PTHREAD` variable is still set so `ArchMultithreadPosix.h` is included as before. Linux/BSD path is unchanged.

## Test plan

- [x] Build on macOS 26.2 (Tahoe) with Xcode 17 / Apple clang 17 — links successfully
- [x] `HAVE_PTHREAD` correctly defined, `ArchMultithreadPosix` compiles
- [x] No impact on non-Apple platforms (guarded by `if(APPLE)`)