### PR TITLE
Keep release stage in snapshot upload path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,9 +715,10 @@ jobs:
           if [[ "${{ env.SYNERGY_VERSION_RELEASE }}" == "true" ]]; then
             sub_dir="release"
           elif [[ "${{ env.SYNERGY_VERSION_SNAPSHOT }}" == "true" ]]; then
-            # Organize snapshots by major.minor.patch for easier navigation.
-            short_version=$(echo "$version" | cut -d'-' -f1 | cut -d'+' -f1)
-            sub_dir="snapshot/$short_version"
+            # Group snapshots by base version, keeping the stage so the folder
+            # matches the release path (i.e. 1.21.2-beta/1.21.2-beta-snapshot+r42).
+            base_version="${version%%-snapshot*}"
+            sub_dir="snapshot/$base_version"
           else
             sub_dir="dev"
           fi


### PR DESCRIPTION
*Generated by Claude*

[S1-2157](https://symless.atlassian.net/browse/S1-2157)

## Test steps

1. Trigger a snapshot CI run on a staged build (push to `beta`, or run the CI workflow via dispatch with package-type `snapshot`).
2. Let the `s3-upload` job run and read the printed "Uploading to AWS S3" URL.

Expect: the snapshot path keeps the stage, e.g. `.../snapshot/1.21.2-beta/1.21.2-beta-snapshot+r42/...`, matching the release path instead of `.../snapshot/1.21.2/...`.

[S1-2157]: https://symless.atlassian.net/browse/S1-2157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ