### PR TITLE
Fix Flatpak builds reporting as dev builds without licensing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -674,6 +674,18 @@ jobs:
 
       - run: git config --global protocol.file.allow always
 
+      # flatpak-builder can't take cmake args, so the build's version flags live
+      # in the manifest. Flip them to match the event; fail loudly if they ever
+      # go missing rather than silently shipping a dev build.
+      - name: Set version flags
+        run: |
+          manifest=extra/deploy/linux/flatpak/com.symless.synergy.yml
+          grep -q -- '-DSYNERGY_VERSION_RELEASE=' "$manifest" \
+            && grep -q -- '-DSYNERGY_VERSION_SNAPSHOT=' "$manifest" \
+            || { echo "::error::version flags missing from $manifest"; exit 1; }
+          sed -i "s|-DSYNERGY_VERSION_RELEASE=[a-zA-Z]*|-DSYNERGY_VERSION_RELEASE=$SYNERGY_VERSION_RELEASE|" "$manifest"
+          sed -i "s|-DSYNERGY_VERSION_SNAPSHOT=[a-zA-Z]*|-DSYNERGY_VERSION_SNAPSHOT=$SYNERGY_VERSION_SNAPSHOT|" "$manifest"
+
       - name: Lint appsteam
         run: flatpak-builder-lint appstream extra/deploy/linux/com.symless.synergy.metainfo.xml
 

--- a/extra/deploy/linux/flatpak/com.symless.synergy.yml
+++ b/extra/deploy/linux/flatpak/com.symless.synergy.yml
@@ -95,6 +95,9 @@ modules:
     buildsystem: cmake-ninja
     config-opts:
       - "-DCMAKE_BUILD_TYPE=Release"
+      # Dev build by default; CI overwrites these for snapshot/release flatpaks.
+      - "-DSYNERGY_VERSION_RELEASE=false"
+      - "-DSYNERGY_VERSION_SNAPSHOT=false"
     sources:
       - type: dir
         path: ../../../../


### PR DESCRIPTION
*Generated by Claude*

[S1-2160](https://symless.atlassian.net/browse/S1-2160)

- [x] Test Flatpak build

## Test steps

1. Trigger the CI workflow manually (Actions, CI, Run workflow) with `package-type: release`.
2. Download the `flatpak-x86_64` artifact and install it: `flatpak install --user <bundle>.flatpak`.
3. Launch Synergy and open the About dialog.

   Expect: the version reads `1.21.2-beta` with no "Development Build" label, and licensing/activation is available like the other release builds.


[S1-2160]: https://symless.atlassian.net/browse/S1-2160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ