### PR TITLE
Add Manjaro support to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -528,6 +528,12 @@ jobs:
             like: "arch"
             config-args: "-G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_DEV_DOCS=ON"
 
+          - name: "manjaro-x86_64"
+            runs-on: ubuntu-latest
+            container: manjarolinux/base:latest
+            like: "arch"
+            config-args: "-G Ninja -DCMAKE_INSTALL_PREFIX=/usr"
+
           - name: "ubuntu-24.04-x86_64"
             runs-on: ubuntu-latest
             container: ubuntu:24.04


### PR DESCRIPTION
*Generated by Claude*

[S1-2164](https://symless.atlassian.net/browse/S1-2164)

## Test steps

1. Open this PR's CI run and find the `manjaro-x86_64` job under `build-linux`.

   Expect: the job passes; its Package step produces `synergy_<version>_manjaro_x86_64.pkg.tar.zst`, and its Test package step installs that package with `pacman -U` and prints the version.


[S1-2164]: https://symless.atlassian.net/browse/S1-2164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ